### PR TITLE
use absolute links so that npm renders properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@
 </div>
 <div align="center">
   <a href="https://www.npmjs.com/package/tram-one">
-    <img src="./docs/images/esm.svg" alt="ESM build size">
+    <img src="https://github.com/Tram-One/tram-one/raw/master/docs/images/esm.svg?sanitize=true" alt="ESM build size">
   </a>
   <a href="https://unpkg.com/tram-one">
-    <img src="./docs/images/umd.svg" alt="UMD build size">
+    <img src="https://github.com/Tram-One/tram-one/raw/master/docs/images/umd.svg?sanitize=true" alt="UMD build size">
   </a>
   <a href="https://join.slack.com/t/tram-one/shared_invite/enQtMjY0NDA3OTg2MzQyLWUyMGIyZTYwNzZkNDJiNWNmNzdiOTMzYjg0YzMzZTkzZDE4MTlmN2Q2YjE0NDIwMGI3ODEzYzQ4ODdlMzQ2ODM">
     <img src="https://img.shields.io/badge/slack-join-83ded3.svg?style=flat" alt="Join Slack">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tram-one",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tram-one",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "🚋 Batteries Included View Framework",
   "main": "dist/tram-one.umd.js",
   "module": "dist/tram-one.esm.js",


### PR DESCRIPTION
## Summary

In npmjs.org, the images for the build sizes did not render because they did not exist locally from that address. This fixes them to github, which kinda stinks, but should be easy to change should the project ever decide to move from github (which is extremely unlikely)

