### PR TITLE
Debugging CircleCI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/node:6.10-browsers
+      - image: circleci/node:8.4-browsers
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/node:8.4-browsers
+      - image: circleci/node:6.10-browsers
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images
@@ -35,4 +35,5 @@ jobs:
 
       - run: npm run lint
 
-      - run: npm test
+      # version of firefox on circleci is too old
+      - run: npm test -- --skip PhantomJS,Firefox

--- a/configs/testem.yml
+++ b/configs/testem.yml
@@ -1,7 +1,8 @@
 framework: jasmine
+host: 127.0.0.1
 launch_in_dev:
-  - PhantomJS
   - Chrome
+  - Firefox
   - Node
 browser_args:
   Chrome:
@@ -11,6 +12,10 @@ browser_args:
       - --disable-gpu
       - --remote-debugging-port=9222
       - --no-sandbox
+  Firefox:
+    mode: dev
+    args:
+      - --headless
 launchers:
   Node:
     command: npm run test-server

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tram-one",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tram-one",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "🚋 Batteries Included View Framework",
   "main": "dist/tram-one.umd.js",
   "module": "dist/tram-one.esm.js",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build-esm": "rollup -c configs/rollup.config.esm.js",
     "build-umd": "rollup -c configs/rollup.config.umd.js",
     "clean": "git clean -Xdf",
-    "test": "testem ci -f configs/testem.yml",
+    "test": "testem ci -f configs/testem.yml --skip PhantomJS,IE",
     "test-build": "npm run build && webpack --config configs/webpack.config.testem.js",
     "test-dev": "testem -f configs/testem.yml",
     "test-server": "jasmine tests/specs/tram-spec.js",


### PR DESCRIPTION
## Summary
Version 4.0.1 (#77) broke CircleCI tests because of the version of Firefox (47 vs the current version 58) has an unreproducible bug. 

For now we are skipping tests in the CircleCI environment on Firefox, until they update the version, or we build our own Docker Image.

## Misc Changes
- Firefox now runs in dev mode with `--headless` flag
- `--skip` flag is used for testem to avoid running in unsupported browsers

## IE and PhantomJS
We are formally dropping support for these browsers for 2 reasons:
1. They are no longer the defacto browsers for their domain (Edge is the new default on windows machines, and headless chrome / headless firefox far out-perform PhantomJS)
2. Template Literals have no trivial transpile equivalent, and these browsers do not support template literals. As it stands, making sites for these browsers would be extremely difficult (unless doing SSR) because of the lack of this support.