### PR TITLE
add terminology and links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,7 +427,7 @@ const voteActions = {
   down: (vote) => vote - 1
 }
 
-const home = (state, actions) => {
+const home = (store, actions) => {
   const upvote = () => {
     actions.up()
   }
@@ -437,7 +437,7 @@ const home = (state, actions) => {
 
   return html`
     <div>
-      <h1> Votes: ${state.votes} </h1>
+      <h1> Votes: ${store.votes} </h1>
       <button onclick=${upvote}>UPVOTE</button>
       <button onclick=${downvote}>DOWNVOTE</button>
     </div>
@@ -585,7 +585,7 @@ Example:
 const app = new Tram()
 const html = Tram.html()
 
-const homePage = (state) => {
+const homePage = () => {
   return html`<div>This is my shiny app!</div>`
 }
 
@@ -632,9 +632,9 @@ Below is a list of definitions for objects used when making a Tram-One app.
 { actionName: (state, value, actions) => newState }
 ```
 An action group is a mapping of action names (string) to functions which return
-a new value for a single store. Action Groups refer to a map of [store](#store)
-names (strings) to an action group. Usually a single app has multiple action
-groups, which together makes the entire app state.
+a new value for a single state. Action Groups refer to a [store](#store) of
+state names (strings) to action groups. Usually a single app has multiple
+action groups, which together makes the entire app state.
 
 You see more examples and details in the
 [`hover-engine`](https://github.com/Tram-one/hover-engine#addactionsactiongroups) project.
@@ -780,7 +780,7 @@ const app2 = (store, actions, params, subroute) => html`
   </div>
 `
 
-const pageWrapper = (state, actions, params, subroute) => html`
+const pageWrapper = (store, actions, params, subroute) => html`
   <div>
     <h1>My Cool App</h1>
     ${subroute}

--- a/README.md
+++ b/README.md
@@ -299,7 +299,8 @@ _Reference: [hyperx](https://github.com/substack/hyperx),
 [belit](https://github.com/Tram-One/belit),
 [rbel](https://github.com/aaaristo/rbel)_
 
-`Tram.dom` is the generic version of `Tram.html` and `Tram.svg`.
+`Tram.dom` is the generic version of [`Tram.html`](#tramhtmlregistry) and
+[`Tram.svg`](#tramsvgregistry).
 It is the driving function that builds document trees, and can be
 used whenever you need to use a namespace other than XHTML and SVG.
 
@@ -339,6 +340,7 @@ app.addRoute('/', home)
 
 #### Constructor Options
 Below are a list of options that can be set when making a Tram-One app.
+
 |option      |description                                      |default value|
 |------------|-------------------------------------------------|-------------|
 |defaultRoute|if we fail to find a route, which route we should render|'/404'|
@@ -347,7 +349,7 @@ Below are a list of options that can be set when making a Tram-One app.
 _Reference: [hover-engine](https://github.com/Tram-One/hover-engine)_
 
 `app.addActions` adds a set of actions that can be triggered in the instance
-of Tram-One. It takes in one argument, [`actionGroups`](actiongroups)
+of Tram-One. It takes in one argument, [`actionGroups`](#action-group)
 
 <details>
 <summary>
@@ -710,7 +712,6 @@ pages.
 `subroute` is the [subroute](#subroute) view, if one is resolved. It is
 another top level component to render inside the view.
 
-
 <details>
 <summary>Example</summary>
 
@@ -730,7 +731,6 @@ const page = (store, actions, params, subroute) => {
 
 </details>
 
-
 ### Element
 An element is a function which takes in `attributes` and `children`. They are
 supposed to mimic the interface for a normal html element as much as possible.
@@ -738,9 +738,10 @@ They are included in the `registry` when setting up an
 [`html`](#tramhtmlregistry) function.
 
 ### Action Group
-An action group is a mapping of a store name (string) to a list of actions
-(functions) which keep track of a single value. Usually a single app has
-multiple action groups, which together makes the entire state.
+An action group is a mapping of action names (string) to functions which return
+a new value for a single store. Action Groups refer to a map of store names
+(strings) to an action group. Usually a single app has multiple action groups,
+which together makes the entire state.
 
 You see more examples and details in the
 [`hover-engine`](https://github.com/Tram-one/hover-engine) project.

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ Batteries Included!
 ### Why?
 Tram-One is a project built to make exposing custom elements easy, and to
 have redux-like state management, and basic routing by default. It was created
-out of  the frustration of having to scaffold the same dependencies over and over
-again.
+out of  the frustration of having to scaffold the same dependencies over and
+over again.
 
 Tram-One was also created to avoid a lot of the syntax that locks you into
 frameworks like Vue and React. The components written here can mimic the syntax
@@ -230,7 +230,12 @@ Here are some most bodacious examples out in the real world
 ## API
 Tram-One has a simple interface to help build your web app.
 
-### `Tram.html([registry])`
+### Static Functions
+Because the following functions are static, you call the function off of
+Tram-One dependency, you do not need to have an instance of a Tram-One app to
+use these functions.
+
+#### `Tram.html([registry])`
 _Reference: [hyperx](https://github.com/substack/hyperx),
 [belit](https://github.com/Tram-One/belit),
 [rbel](https://github.com/aaaristo/rbel)_
@@ -239,9 +244,6 @@ _Reference: [hyperx](https://github.com/substack/hyperx),
 template literals into Node DOM trees.
 It can take in an optional [`registry`](#registry), which is a mapping of tag
 names to functions that render your custom tags.
-
-Because it is static, you call the function off of Tram-One, you
-do not need to have an instance of Tram-One to use this function.
 
 <details>
 <summary>
@@ -285,7 +287,7 @@ const home = () => {
 
 </details>
 
-### `Tram.svg([registry])`
+#### `Tram.svg([registry])`
 _Reference: [hyperx](https://github.com/substack/hyperx),
 [belit](https://github.com/Tram-One/belit),
 [rbel](https://github.com/aaaristo/rbel)_
@@ -294,7 +296,7 @@ _Reference: [hyperx](https://github.com/substack/hyperx),
 elements in the appropriate SVG namespace. Use this method if you're building
 components that are SVG.
 
-### `Tram.dom([namespace, registry])`
+#### `Tram.dom([namespace, registry])`
 _Reference: [hyperx](https://github.com/substack/hyperx),
 [belit](https://github.com/Tram-One/belit),
 [rbel](https://github.com/aaaristo/rbel)_
@@ -304,7 +306,7 @@ _Reference: [hyperx](https://github.com/substack/hyperx),
 It is the driving function that builds document trees, and can be
 used whenever you need to use a namespace other than XHTML and SVG.
 
-### `Tram.route()`
+#### `Tram.route()`
 `Tram.route` is a static method which is a shorthand for creating
 the subroutes for the [`app.addRoute`](#appaddroutepath-page-subroutes)
 method. The resulting function takes in [`path`](#path), [`component`](#top-level-component), and
@@ -314,7 +316,7 @@ method. The resulting function takes in [`path`](#path), [`component`](#top-leve
 See [`app.addRoute`](#appaddroutepath-page-subroutes) for a an example of
 nested routes using `Tram.route`.
 
-### `Tram.constructor([options])`
+#### `Tram.constructor([options])`
 `new Tram()` returns an instance of a Tram-One app. The constructor
 takes in an [`options`](#constructor-options) object.
 
@@ -338,14 +340,18 @@ app.addRoute('/', home)
 
 </details>
 
-#### Constructor Options
+##### Constructor Options
 Below are a list of options that can be set when making a Tram-One app.
 
-|option      |description                                      |default value|
-|------------|-------------------------------------------------|-------------|
-|defaultRoute|if we fail to find a route, which route we should render|'/404'|
+|option        |description                                             |default value|type   |
+|--------------|--------------------------------------------------------|-------------|-------|
+|`defaultRoute`|if we fail to find a route, which route we should render|'/404'       |string |
 
-### `app.addActions(actionGroups)`
+### App Functions
+The following functions should be called on an instance of a Tram-One app (see
+the app [constructor](#tramconstructoroptions) above).
+
+#### `app.addActions(actionGroups)`
 _Reference: [hover-engine](https://github.com/Tram-One/hover-engine)_
 
 `app.addActions` adds a set of actions that can be triggered in the instance
@@ -392,7 +398,7 @@ app.addActions({votes: voteActions})
 
 </details>
 
-### `app.addListener(listener)`
+#### `app.addListener(listener)`
 _Reference: [hover-engine](https://github.com/Tram-One/hover-engine)_
 
 `app.addListener` adds a function that triggers on every action call Tram-One.
@@ -400,18 +406,7 @@ This can be used to save state in localstorage, or to debug the state of the
 store as actions are called. This should not be used to update the DOM, only
 trigger side-effects.
 
-It takes in one argument, a function, which provides 4 arguements, the store,
-the actions, the action name, and the action argument:<br>
-the store contains the key-value pair that you get as the first parameter for
-pages<br>
-the actions is an object of callable functions that you get as the second
-parameter for pages<br>
-the action name is the last action that triggered the listener (may be
-undefined)<br>
-the actin argument was anything that was passed into the action call (may be
-undefined)<br>
-
-In the store and actions here are actually identical to the store and actions you recieve in routes.
+It takes in one argument, a [listener](#listener).
 
 <details>
 <summary>
@@ -460,7 +455,7 @@ app.addActions({votes: voteActions})
 
 </details>
 
-### `app.addRoute(path, page[, subroutes])`
+#### `app.addRoute(path, page[, subroutes])`
 _Reference: [rlite](https://github.com/chrisdavies/rlite)_
 
 `app.addRoute` will associate a [path](#path) with a
@@ -552,7 +547,7 @@ app.addRoute('/404', noPage)
 
 </details>
 
-### `app.start(selector[, pathName])`
+#### `app.start(selector[, pathName])`
 
 `app.start` will kick off the app. Once this is called the app is mounted onto the
 `selector`.<br>
@@ -600,7 +595,7 @@ app.start('.main')
 
 </details>
 
-### `app.mount(selector, pathName, store, actions)`
+#### `app.mount(selector, pathName, store, actions)`
 **WARNING: INTENDED FOR INTERNAL USE ONLY**
 
 `app.mount` matches a route from `pathName`, passes in a `store` and `actions`
@@ -612,7 +607,7 @@ testing.
 
 **YOU SHOULD NEVER CALL THIS DIRECTLY FOR YOUR APP**
 
-### `app.toNode(pathName[, store, actions])`
+#### `app.toNode(pathName[, store, actions])`
 
 `app.toNode` returns a HTMLNode of the app for a given route and store. The
 function matches a route from `pathName`, and either takes in a `store`, or
@@ -621,7 +616,7 @@ uses the default store (that's been created by adding reducers).
 While initially created to clean up the code in the library, this can be useful
 if you want to manually attach the HTMLNode that Tram-One builds to whatever.
 
-### `app.toString(pathName[, store])`
+#### `app.toString(pathName[, store])`
 
 `app.toString` returns a string of the app for a given route and store. It has
 the same interface at `app.toNode`, and basically just calls `.outerHTML` on
@@ -632,7 +627,89 @@ This can be useful if you want to do server-sider rendering or testing.
 ## Terminology
 Below is a list of definitions for objects used when making a Tram-One app.
 
-### registry
+### Action Group
+```js
+{ actionName: (state, value, actions) => newState }
+```
+An action group is a mapping of action names (string) to functions which return
+a new value for a single store. Action Groups refer to a map of [store](#store)
+names (strings) to an action group. Usually a single app has multiple action
+groups, which together makes the entire app state.
+
+You see more examples and details in the
+[`hover-engine`](https://github.com/Tram-one/hover-engine#addactionsactiongroups) project.
+
+<details>
+<summary>Example</summary>
+
+```javascript
+const actionGroup = {
+  counter: {
+    init: () => 0,
+    up: (state) => state + 1
+  }
+}
+```
+
+</details>
+
+### Element
+```js
+(attributes, children) => DOM
+```
+An element is a function which takes in `attributes` and `children`. They are
+supposed to mimic the interface for a normal html element as much as possible.
+They are included in the `registry` when setting up an
+[`html`](#tramhtmlregistry) function.
+
+<details>
+<summary>Example</summary>
+
+```javascript
+/* usage: <CustomList title="Sale">
+            <li>Radio</li>
+            <li>TV</li>
+          </CustomList>
+ */
+const CustomList = (attrs, children) => html`
+  <div>
+    <h3>${attrs.title}</h3>
+    <ul>
+      ${children}
+    </ul>
+  </div>
+`
+```
+
+</details>
+
+### Listener
+```js
+(store, actions, actionName, actionArguments) => side-effect
+```
+
+A listener is a function which can be used to debug an application, or trigger
+certain side-effects when the state is updated. Many of the properties passed
+into a listener are the same as the ones used in
+[top level componenets](#top-level-components).
+
+For details on the listener object,
+[read here on the hover-engine project](https://github.com/Tram-One/hover-engine#addlistenerlistener).
+
+### Path
+```js
+'/path/with/:path/:params/and?query=variables'
+```
+A path is a string that describes how to get to different [routes](#route) in
+a Tram-One app. It can include path variables, query params, and hash values.
+
+You can see more examples and details on the types of routes in the
+[rlite](https://github.com/chrisdavies/rlite) project.
+
+### Registry
+```js
+{ tagName: element }
+```
 A registry is a mapping of tags to elements. A registry is usually passed into
 the static functions that build DOM elements (
 [`html`](#tramhtmlregistry), [`svg`](#tramsvgregistry), or
@@ -657,14 +734,10 @@ const html = Tram.html({
 
 </details>
 
-### Path
-A path is a string that describes how to get to different [routes](#route) in
-a Tram-One app. It can include path variables, query params, and hash values.
-
-You can see more examples and details on the types of routes in the
-[rlite](https://github.com/chrisdavies/rlite) project.
-
 ### Route
+```js
+{ path, component, subroutes }
+```
 A Route is the association between a [path](#path), a
 [top level component](#top-level-component), and any [subroutes](#subroute)
 that may exist under that route (if a different top level component would
@@ -673,7 +746,18 @@ render as a result).
 When building [subroutes](#subroute), you should use the static method
 [`Tram.route`](#tramroute) to build route objects.
 
+### Store
+```js
+{ state: value }
+```
+A store is a collection of values. It is updated by calling
+[`actions`](#actions), and passed into the [top level components]
+(#top-level-component).
+
 ### Subroute
+```js
+[route(path, topLevelComponent, subroutes), ...]
+```
 A subroute is a [top level component](#top-level-component) that should render
 inside of another top level component based on the [path](#path). Subroutes let
 you describe your views as containers of other views based on the path. This is
@@ -684,20 +768,37 @@ and footer for every page.
 <summary>Example</summary>
 
 ```js
+const app1 = (store, actions, params, subroute) => html`
+  <div>
+    <div>My First App</div>
+  </div>
+`
 
-pageWrapper = (state, actions, params, subroute) => html`
+const app2 = (store, actions, params, subroute) => html`
+  <div>
+    <div>My Better App</div>
+  </div>
+`
+
+const pageWrapper = (state, actions, params, subroute) => html`
   <div>
     <h1>My Cool App</h1>
     ${subroute}
     <footer>Copyright 2018</footer>
   </div>
 `
-app.addRoute('/', pageWrapper)
+app.addRoute('/', pageWrapper, [
+  route('first', app1),
+  route('second', app2)
+])
 ```
 
 </details>
 
 ### Top Level Component
+```js
+(store, actions, params, subroute) => DOM
+```
 Top level components are functions that take in `store`, `actions`, `params`,
 and `subroute`. Top level components are passed in the
 [`app.addRoute`](#appaddroutepath-page-subroutes) function, and
@@ -706,7 +807,7 @@ views. Since you usually have one per route, it is fair to also call these
 pages.
 
 `store` is a mapping of the different reducers (strings) to their value
-(see addAction).
+(see [store](#store)).
 `actions` is an object with methods from the defined reducers.
 `params` are any path or query variable that is inherited from the route.
 `subroute` is the [subroute](#subroute) view, if one is resolved. It is
@@ -726,35 +827,6 @@ const page = (store, actions, params, subroute) => {
       <a href="/book/${params.bookId}/pages/${nextPage}">Next Page</a>
     </div>
   `
-}
-```
-
-</details>
-
-### Element
-An element is a function which takes in `attributes` and `children`. They are
-supposed to mimic the interface for a normal html element as much as possible.
-They are included in the `registry` when setting up an
-[`html`](#tramhtmlregistry) function.
-
-### Action Group
-An action group is a mapping of action names (string) to functions which return
-a new value for a single store. Action Groups refer to a map of store names
-(strings) to an action group. Usually a single app has multiple action groups,
-which together makes the entire state.
-
-You see more examples and details in the
-[`hover-engine`](https://github.com/Tram-one/hover-engine) project.
-
-<details>
-<summary>Example</summary>
-
-```javascript
-const actionGroup = {
-  counter: {
-    init: () => 0,
-    up: (state) => state + 1
-  }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ _Reference: [hyperx](https://github.com/substack/hyperx),
 
 `Tram.html` returns a function that can be used to transform
 template literals into Node DOM trees.
-It can take in an optional `registry`, which is a mapping of tag
+It can take in an optional [`registry`](#registry), which is a mapping of tag
 names to functions that render your custom tags.
 
 Because it is static, you call the function off of Tram-One, you
@@ -290,8 +290,8 @@ _Reference: [hyperx](https://github.com/substack/hyperx),
 [belit](https://github.com/Tram-One/belit),
 [rbel](https://github.com/aaaristo/rbel)_
 
-`Tram.svg` is the same as `Tram.html`, but will create elements
-in the appropriate SVG namespace. Use this method if you're building
+`Tram.svg` is the same as [`Tram.html`](#tramhtmlregistry), but will create
+elements in the appropriate SVG namespace. Use this method if you're building
 components that are SVG.
 
 ### `Tram.dom([namespace, registry])`
@@ -305,18 +305,17 @@ used whenever you need to use a namespace other than XHTML and SVG.
 
 ### `Tram.route()`
 `Tram.route` is a static method which is a shorthand for creating
-the subroutes for the `app.addRoute` method (detailed below).
-The resulting function takes in `path`, `component`, and `subroutes`,
-mimicking the interface used in `addRoute`.
+the subroutes for the [`app.addRoute`](#appaddroutepath-page-subroutes)
+method. The resulting function takes in [`path`](#path), [`component`](#top-level-component), and
+[`subroutes`](#subroute), mimicking the interface used in
+[`app.addRoute`](#appaddroutepath-page-subroutes).
 
-See `app.addRoute` for a an example of nested routes using `Tram.route`.
+See [`app.addRoute`](#appaddroutepath-page-subroutes) for a an example of
+nested routes using `Tram.route`.
 
 ### `Tram.constructor([options])`
-`new Tram()` returns an instance of the Tram. The constructor
-takes in an `options` object, which can have a `defaultRoute`.
-
-`defaultRoute` by default is `/404`, but you can set it to whatever path
-you want to load when path matching fails.
+`new Tram()` returns an instance of a Tram-One app. The constructor
+takes in an [`options`](#constructor-options) object.
 
 <details>
 <summary>
@@ -338,13 +337,17 @@ app.addRoute('/', home)
 
 </details>
 
+#### Constructor Options
+Below are a list of options that can be set when making a Tram-One app.
+|option      |description                                      |default value|
+|------------|-------------------------------------------------|-------------|
+|defaultRoute|if we fail to find a route, which route we should render|'/404'|
+
 ### `app.addActions(actionGroups)`
 _Reference: [hover-engine](https://github.com/Tram-One/hover-engine)_
 
-`app.addActions` adds a set of actions that can be triggered in the instance of Tram-One.
-It takes in one argument, an object where:<br>
-the keys are values that can be pulled in the view<br>
-the values are actions that can be triggered in the view<br>
+`app.addActions` adds a set of actions that can be triggered in the instance
+of Tram-One. It takes in one argument, [`actionGroups`](actiongroups)
 
 <details>
 <summary>
@@ -390,15 +393,21 @@ app.addActions({votes: voteActions})
 ### `app.addListener(listener)`
 _Reference: [hover-engine](https://github.com/Tram-One/hover-engine)_
 
-`app.addListener` adds a function that triggers on every action call Tram-One. This can be used to
-save state in localstorage, or to debug the state of the store as actions are called. This should
-not be used to update the DOM, only trigger side-effects.
+`app.addListener` adds a function that triggers on every action call Tram-One.
+This can be used to save state in localstorage, or to debug the state of the
+store as actions are called. This should not be used to update the DOM, only
+trigger side-effects.
 
-It takes in one argument, a function, which provides 4 arguements, the store, the actions, the action name, and the action argument:<br>
-the store contains the key-value pair that you get as the first parameter for pages<br>
-the actions is an object of callable functions that you get as the second parameter for pages<br>
-the action name is the last action that triggered the listener (may be undefined)<br>
-the actin argument was anything that was passed into the action call (may be undefined)<br>
+It takes in one argument, a function, which provides 4 arguements, the store,
+the actions, the action name, and the action argument:<br>
+the store contains the key-value pair that you get as the first parameter for
+pages<br>
+the actions is an object of callable functions that you get as the second
+parameter for pages<br>
+the action name is the last action that triggered the listener (may be
+undefined)<br>
+the actin argument was anything that was passed into the action call (may be
+undefined)<br>
 
 In the store and actions here are actually identical to the store and actions you recieve in routes.
 
@@ -452,17 +461,16 @@ app.addActions({votes: voteActions})
 ### `app.addRoute(path, page[, subroutes])`
 _Reference: [rlite](https://github.com/chrisdavies/rlite)_
 
-`app.addRoute` will associate a component with a route.<br>
-`path` should be a matchable route for the application. Look up
-[rlite](https://github.com/chrisdavies/rlite)
-to see all the possible options here.<br>
-`page` should be a function that takes in a `store`, `actions`, `params`, and `child`.<br>
-`subroutes` should be a list of route objects (see `Tram.route`). Subroutes allow
-you to have pages that act as containers for other pages (like a surrounding header
-and footer tag for a page). The `child` parameter for the `page` function is filled
-in when a subroute is resolved.
+`app.addRoute` will associate a [path](#path) with a
+[top level component](#top-level-component).<br>
+`path` should be a matchable string for the application. See [path](#path).<br>
+`page` should be a [top level component](#top-level-component).<br>
+`subroutes` should be a list of [route objects](#route). The `subroute`
+parameter for the [top level component](#top-level-component) function is
+filled in when a subroute is resolved. See [subroute](#subroute).
 
-The `params` object passed into the `page` function will have any path parameters and query params.
+The `params` object passed into the [top level component](#top-level-component)
+will have any path parameters and query params.
 
 <details>
 <summary>
@@ -509,20 +517,20 @@ const app = new Tram()
 const html = Tram.html()
 const route = Tram.route()
 
-const homePage = (store, actions, params, child) => {
+const homePage = (store, actions, params, subroute) => {
   return html`
     <div>
       <h1>This is my shiny new app!</h1>
-      ${child}
+      ${subroute}
     </div>
   `
 }
 
-const animalsPage = (store, actions, params, child) => {
+const animalsPage = (store, actions, params, subroute) => {
   return html`
     <div>
       <h2>Animals Rule</h2>
-      ${child}
+      ${subroute}
     </div>
   `
 }
@@ -563,7 +571,7 @@ Example:
 </summary>
 
 ```html
-/* index.html */
+<!-- index.html -->
 <html>
   <head>
     <title>Tram One</title>
@@ -593,8 +601,9 @@ app.start('.main')
 ### `app.mount(selector, pathName, store, actions)`
 **WARNING: INTENDED FOR INTERNAL USE ONLY**
 
-`app.mount` matches a route from `pathName`, passes in a `store` and `actions` object,
-and either creates a child div, or updates a child div under `selector`.
+`app.mount` matches a route from `pathName`, passes in a `store` and `actions`
+object, and either creates a child div, or updates a child div under
+`selector`.
 
 This was created to clean up the code in the library, but may be useful for
 testing.
@@ -613,16 +622,149 @@ if you want to manually attach the HTMLNode that Tram-One builds to whatever.
 ### `app.toString(pathName[, store])`
 
 `app.toString` returns a string of the app for a given route and store. It has
-the same interface at `app.toNode`, and basically just calls `.outerHTML` (or
-`toString` on the server) on the node.
+the same interface at `app.toNode`, and basically just calls `.outerHTML` on
+the node.
 
 This can be useful if you want to do server-sider rendering or testing.
+
+## Terminology
+Below is a list of definitions for objects used when making a Tram-One app.
+
+### registry
+A registry is a mapping of tags to elements. A registry is usually passed into
+the static functions that build DOM elements (
+[`html`](#tramhtmlregistry), [`svg`](#tramsvgregistry), or
+[`dom`](#tramdomnamespace-registry)).
+The strings used as values can be of pretty much any syntax, allowing you to
+write React like capitalized tags, web-component like hyphenated tags, or
+lowercase single words, like real HTML tags.
+
+It is recommended that you write elements in separate files, and require them
+in your registry.
+
+<details>
+<summary>Example</summary>
+
+```js
+const html = Tram.html({
+  'my-beginning': require('./elements/my-beginning.js'),
+  'Ending': () => require('./elements/Ending.js'),
+  'content': () => require('./elements/content.js')
+})
+```
+
+</details>
+
+### Path
+A path is a string that describes how to get to different [routes](#route) in
+a Tram-One app. It can include path variables, query params, and hash values.
+
+You can see more examples and details on the types of routes in the
+[rlite](https://github.com/chrisdavies/rlite) project.
+
+### Route
+A Route is the association between a [path](#path), a
+[top level component](#top-level-component), and any [subroutes](#subroute)
+that may exist under that route (if a different top level component would
+render as a result).
+
+When building [subroutes](#subroute), you should use the static method
+[`Tram.route`](#tramroute) to build route objects.
+
+### Subroute
+A subroute is a [top level component](#top-level-component) that should render
+inside of another top level component based on the [path](#path). Subroutes let
+you describe your views as containers of other views based on the path. This is
+useful for many cases, most commonly if you have a surrounding header, nav,
+and footer for every page.
+
+<details>
+<summary>Example</summary>
+
+```js
+
+pageWrapper = (state, actions, params, subroute) => html`
+  <div>
+    <h1>My Cool App</h1>
+    ${subroute}
+    <footer>Copyright 2018</footer>
+  </div>
+`
+app.addRoute('/', pageWrapper)
+```
+
+</details>
+
+### Top Level Component
+Top level components are functions that take in `store`, `actions`, `params`,
+and `subroute`. Top level components are passed in the
+[`app.addRoute`](#appaddroutepath-page-subroutes) function, and
+subsequent subroutes. They are how you connect the logic of your app to the
+views. Since you usually have one per route, it is fair to also call these
+pages.
+
+`store` is a mapping of the different reducers (strings) to their value
+(see addAction).
+`actions` is an object with methods from the defined reducers.
+`params` are any path or query variable that is inherited from the route.
+`subroute` is the [subroute](#subroute) view, if one is resolved. It is
+another top level component to render inside the view.
+
+
+<details>
+<summary>Example</summary>
+
+```javascript
+// example route /book/:bookId/pages/:pageId
+const page = (store, actions, params, subroute) => {
+  const nextPage = params.pageId + 1
+  return html`
+    <div>
+      <h2>Book ${params.bookId}</h2>
+      <div>You are on page ${params.pageId}</div>
+      <a href="/book/${params.bookId}/pages/${nextPage}">Next Page</a>
+    </div>
+  `
+}
+```
+
+</details>
+
+
+### Element
+An element is a function which takes in `attributes` and `children`. They are
+supposed to mimic the interface for a normal html element as much as possible.
+They are included in the `registry` when setting up an
+[`html`](#tramhtmlregistry) function.
+
+### Action Group
+An action group is a mapping of a store name (string) to a list of actions
+(functions) which keep track of a single value. Usually a single app has
+multiple action groups, which together makes the entire state.
+
+You see more examples and details in the
+[`hover-engine`](https://github.com/Tram-one/hover-engine) project.
+
+<details>
+<summary>Example</summary>
+
+```javascript
+const actionGroup = {
+  counter: {
+    init: () => 0,
+    up: (state) => state + 1
+  }
+}
+```
+
+</details>
 
 ## Development
 
 ### Slack
 
-If you want to start contributing, need help, or would just like to say hi, [join our slack channel](https://join.slack.com/t/tram-one/shared_invite/enQtMjY0NDA3OTg2MzQyLWUyMGIyZTYwNzZkNDJiNWNmNzdiOTMzYjg0YzMzZTkzZDE4MTlmN2Q2YjE0NDIwMGI3ODEzYzQ4ODdlMzQ2ODM)!
+If you want to start contributing, need help, or would just like to say hi,
+[join our slack channel](https://join.slack.com/t/tram-one/shared_invite/enQtMjY0NDA3OTg2MzQyLWUyMGIyZTYwNzZkNDJiNWNmNzdiOTMzYjg0YzMzZTkzZDE4MTlmN2Q2YjE0NDIwMGI3ODEzYzQ4ODdlMzQ2ODM)!
 
 ### Commands
 

--- a/README.md
+++ b/README.md
@@ -647,7 +647,7 @@ state names (strings) to action groups. Usually a single app has multiple
 action groups, which together makes the entire app state.
 
 You see more examples and details in the
-[`hover-engine`](https://github.com/Tram-one/hover-engine#addactionsactiongroups) project.
+[hover-engine](https://github.com/Tram-one/hover-engine#addactionsactiongroups) project.
 
 <details>
 <summary>Example</summary>

--- a/README.md
+++ b/README.md
@@ -231,9 +231,12 @@ Here are some most bodacious examples out in the real world
 Tram-One has a simple interface to help build your web app.
 
 ### Static Functions
-Because the following functions are static, you call the function off of
-Tram-One dependency, you do not need to have an instance of a Tram-One app to
+Because the following functions are static, you call the function off of the
+Tram-One dependency. You do not need to have an instance of a Tram-One app to
 use these functions.
+
+To remain consistent, all these functions take in options, and return
+new functions to be called on their own.
 
 #### `Tram.html([registry])`
 _Reference: [hyperx](https://github.com/substack/hyperx),
@@ -309,14 +312,15 @@ used whenever you need to use a namespace other than XHTML and SVG.
 #### `Tram.route()`
 `Tram.route` is a static method which is a shorthand for creating
 the subroutes for the [`app.addRoute`](#appaddroutepath-page-subroutes)
-method. The resulting function takes in [`path`](#path), [`component`](#top-level-component), and
+method. The resulting function takes in [`path`](#path),
+[`component`](#top-level-component), and
 [`subroutes`](#subroute), mimicking the interface used in
 [`app.addRoute`](#appaddroutepath-page-subroutes).
 
 See [`app.addRoute`](#appaddroutepath-page-subroutes) for a an example of
 nested routes using `Tram.route`.
 
-#### `Tram.constructor([options])`
+### `new Tram([options])`
 `new Tram()` returns an instance of a Tram-One app. The constructor
 takes in an [`options`](#constructor-options) object.
 
@@ -340,7 +344,7 @@ app.addRoute('/', home)
 
 </details>
 
-##### Constructor Options
+#### Constructor Options
 Below are a list of options that can be set when making a Tram-One app.
 
 |option        |description                                             |default value|type   |
@@ -349,13 +353,16 @@ Below are a list of options that can be set when making a Tram-One app.
 
 ### App Functions
 The following functions should be called on an instance of a Tram-One app (see
-the app [constructor](#tramconstructoroptions) above).
+the app [`constructor`](#new-tramoptions) above).
+
+These functions all return an instance of the app, so that it is easy to chain
+one after the other.
 
 #### `app.addActions(actionGroups)`
 _Reference: [hover-engine](https://github.com/Tram-One/hover-engine)_
 
 `app.addActions` adds a set of actions that can be triggered in the instance
-of Tram-One. It takes in one argument, [`actionGroups`](#action-group)
+of a Tram-One app. It takes in one argument, [`actionGroups`](#action-group)
 
 <details>
 <summary>
@@ -401,12 +408,12 @@ app.addActions({votes: voteActions})
 #### `app.addListener(listener)`
 _Reference: [hover-engine](https://github.com/Tram-One/hover-engine)_
 
-`app.addListener` adds a function that triggers on every action call Tram-One.
-This can be used to save state in localstorage, or to debug the state of the
-store as actions are called. This should not be used to update the DOM, only
-trigger side-effects.
+`app.addListener` adds a function that triggers on every action call. This can
+be used to save state in localstorage, or to debug the state of the store as
+actions are called. This should not be used to update the DOM, only trigger
+side-effects.
 
-It takes in one argument, a [listener](#listener).
+It takes in one argument, a [`listener`](#listener).
 
 <details>
 <summary>
@@ -458,15 +465,17 @@ app.addActions({votes: voteActions})
 #### `app.addRoute(path, page[, subroutes])`
 _Reference: [rlite](https://github.com/chrisdavies/rlite)_
 
-`app.addRoute` will associate a [path](#path) with a
-[top level component](#top-level-component).<br>
-`path` should be a matchable string for the application. See [path](#path).<br>
-`page` should be a [top level component](#top-level-component).<br>
-`subroutes` should be a list of [route objects](#route). The `subroute`
-parameter for the [top level component](#top-level-component) function is
-filled in when a subroute is resolved. See [subroute](#subroute).
+`app.addRoute` will associate a [`path`](#path) with a
+[`top level component`](#top-level-component).<br>
+`path` should be a matchable string for the application. See
+[`path`](#path).<br>
+`page` should be a [`top level component`](#top-level-component).<br>
+`subroutes` should be a list of [`route objects`](#route). The `subroute`
+parameter for the [`top level component`](#top-level-component) function is
+filled in when a subroute is resolved. See [`subroute`](#subroute).
 
-The `params` object passed into the [top level component](#top-level-component)
+The `params` object passed into the
+[`top level component`](#top-level-component)
 will have any path parameters and query params.
 
 <details>
@@ -627,12 +636,13 @@ This can be useful if you want to do server-sider rendering or testing.
 ## Terminology
 Below is a list of definitions for objects used when making a Tram-One app.
 
-### Action Group
+### Action Groups
 ```js
-{ actionName: (state, value, actions) => newState }
+actionGroup = { actionName: (state, value, actions) => newState }
+actionGroups = { storeName: actionGroup }
 ```
 An action group is a mapping of action names (string) to functions which return
-a new value for a single state. Action Groups refer to a [store](#store) of
+a new value for a single state. Action Groups refer to a [`store`](#store) of
 state names (strings) to action groups. Usually a single app has multiple
 action groups, which together makes the entire app state.
 
@@ -691,7 +701,7 @@ const CustomList = (attrs, children) => html`
 A listener is a function which can be used to debug an application, or trigger
 certain side-effects when the state is updated. Many of the properties passed
 into a listener are the same as the ones used in
-[top level componenets](#top-level-components).
+[`top level componenets`](#top-level-components).
 
 For details on the listener object,
 [read here on the hover-engine project](https://github.com/Tram-One/hover-engine#addlistenerlistener).
@@ -700,7 +710,7 @@ For details on the listener object,
 ```js
 '/path/with/:path/:params/and?query=variables'
 ```
-A path is a string that describes how to get to different [routes](#route) in
+A path is a string that describes how to get to different [`routes`](#route) in
 a Tram-One app. It can include path variables, query params, and hash values.
 
 You can see more examples and details on the types of routes in the
@@ -738,12 +748,12 @@ const html = Tram.html({
 ```js
 { path, component, subroutes }
 ```
-A Route is the association between a [path](#path), a
-[top level component](#top-level-component), and any [subroutes](#subroute)
+A Route is the association between a [`path`](#path), a
+[`top level component`](#top-level-component), and any [`subroutes`](#subroute)
 that may exist under that route (if a different top level component would
 render as a result).
 
-When building [subroutes](#subroute), you should use the static method
+When building [`subroutes`](#subroute), you should use the static method
 [`Tram.route`](#tramroute) to build route objects.
 
 ### Store
@@ -758,11 +768,11 @@ A store is a collection of values. It is updated by calling
 ```js
 [route(path, topLevelComponent, subroutes), ...]
 ```
-A subroute is a [top level component](#top-level-component) that should render
-inside of another top level component based on the [path](#path). Subroutes let
-you describe your views as containers of other views based on the path. This is
-useful for many cases, most commonly if you have a surrounding header, nav,
-and footer for every page.
+A subroute is a [`top level component`](#top-level-component) that should
+render inside of another top level component based on the [`path`](#path).
+Subroutes let you describe your views as containers of other views based on
+the path. This is useful for many cases, most commonly if you have a
+surrounding header, nav, and footer for every page.
 
 <details>
 <summary>Example</summary>
@@ -807,10 +817,11 @@ views. Since you usually have one per route, it is fair to also call these
 pages.
 
 `store` is a mapping of the different reducers (strings) to their value
-(see [store](#store)).
-`actions` is an object with methods from the defined reducers.
-`params` are any path or query variable that is inherited from the route.
-`subroute` is the [subroute](#subroute) view, if one is resolved. It is
+(see [`store`](#store)).
+`actions` is an object with methods from the defined reducers (see [`action groups`](#action-group).
+`params` are any path or query variable that is inherited from the route (see
+[`path`](#path)).
+`subroute` is the [`subroute`](#subroute) view, if one is resolved. It is
 another top level component to render inside the view.
 
 <details>

--- a/docs/images/esm.svg
+++ b/docs/images/esm.svg
@@ -14,7 +14,7 @@
   <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
     <text x="16.5" y="15" fill="#010101" fill-opacity=".3">esm</text>
     <text x="16.5" y="14">esm</text>
-    <text x="56.5" y="15" fill="#010101" fill-opacity=".3">3.63 kB</text>
-    <text x="56.5" y="14">3.63 kB</text>
+    <text x="56.5" y="15" fill="#010101" fill-opacity=".3">3.66 kB</text>
+    <text x="56.5" y="14">3.66 kB</text>
   </g>
 </svg>

--- a/tram-one.js
+++ b/tram-one.js
@@ -46,9 +46,9 @@ class Tram {
     if (subroutes) {
       subroutes.forEach(subroute => {
         const newPath = path + subroute.path
-        const newPage = (store, actions, params, child) => {
-          const newChild = subroute.component(store, actions, params, child)
-          return page(store, actions, params, newChild)
+        const newPage = (store, actions, params, resolvedSubroute) => {
+          const newSubroute = subroute.component(store, actions, params, resolvedSubroute)
+          return page(store, actions, params, newSubroute)
         }
         this.addRoute(newPath, newPage, subroute.subroutes)
       })


### PR DESCRIPTION
## Summary
This should make the README easier to read and more consistent.
Preview: https://github.com/Tram-One/tram-one/blob/terminology/README.md#api

Resolves #88 
and resolves #47 