### PR TITLE
Make Default Export ES Module

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
   <a href="https://www.npmjs.com/package/tram-one">
     <img src="https://github.com/Tram-One/tram-one/raw/master/docs/images/esm.svg?sanitize=true" alt="ESM build size">
   </a>
-  <a href="https://unpkg.com/tram-one">
+  <a href="https://unpkg.com/tram-one/dist/tram-one.umd.js">
     <img src="https://github.com/Tram-One/tram-one/raw/master/docs/images/umd.svg?sanitize=true" alt="UMD build size">
   </a>
   <a href="https://join.slack.com/t/tram-one/shared_invite/enQtMjY0NDA3OTg2MzQyLWUyMGIyZTYwNzZkNDJiNWNmNzdiOTMzYjg0YzMzZTkzZDE4MTlmN2Q2YjE0NDIwMGI3ODEzYzQ4ODdlMzQ2ODM">
@@ -40,7 +40,7 @@ Or, you can use the Universal Module Definition (UMD) in a script tag:
 
 ```html
 <head>
-  <script src="https://unpkg.com/tram-one"></script>
+  <script src="https://unpkg.com/tram-one/dist/tram-one.umd.js"></script>
 </head>
 ```
 

--- a/configs/rollup.config.umd.js
+++ b/configs/rollup.config.umd.js
@@ -35,7 +35,7 @@ export default {
   external: ['domino'],
   globals: {domino: 'domino'},
   output: {
-    file: pkg.main,
+    file: pkg.umd,
     format: 'umd'
   },
   plugins: plugins,

--- a/dev-scripts/badge.js
+++ b/dev-scripts/badge.js
@@ -1,21 +1,26 @@
-module.exports = (label, value) => `<svg xmlns="http://www.w3.org/2000/svg" width="82" height="20">
+module.exports = (label, value) => {
+  const labelWidth = label.length * 11
+  const valueWidth = 58 + (value.length * 4)
+  const labelOffset = 16.5
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${valueWidth}" height="20">
   <linearGradient id="b" x2="0" y2="100%">
     <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
     <stop offset="1" stop-opacity=".1"/>
   </linearGradient>
   <mask id="a">
-    <rect width="82" height="20" rx="3" fill="#fff"/>
+    <rect width="${valueWidth}" height="20" rx="3" fill="#fff"/>
   </mask>
   <g mask="url(#a)">
-    <path fill="#555" d="M0 0h33v20H0z"/>
-    <path fill="#e05d44" d="M33 0h49v20H33z"/>
-    <path fill="url(#b)" d="M0 0h82v20H0z"/>
+    <path fill="#555" d="M0 0h${labelWidth}v20H0z"/>
+    <path fill="#e05d44" d="M${labelWidth} 0h100v20H${labelWidth}z"/>
+    <path fill="url(#b)" d="M0 0h${valueWidth}v20H0z"/>
   </g>
   <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
-    <text x="16.5" y="15" fill="#010101" fill-opacity=".3">${label}</text>
-    <text x="16.5" y="14">${label}</text>
-    <text x="56.5" y="15" fill="#010101" fill-opacity=".3">${value}</text>
-    <text x="56.5" y="14">${value}</text>
+    <text x="${labelOffset}" y="15" fill="#010101" fill-opacity=".3">${label}</text>
+    <text x="${labelOffset}" y="14">${label}</text>
+    <text x="59" y="15" fill="#010101" fill-opacity=".3">${value}</text>
+    <text x="59" y="14">${value}</text>
   </g>
 </svg>
 `
+}

--- a/docs/images/esm.svg
+++ b/docs/images/esm.svg
@@ -1,20 +1,20 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="90" height="20">
+<svg xmlns="http://www.w3.org/2000/svg" width="86" height="20">
   <linearGradient id="b" x2="0" y2="100%">
     <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
     <stop offset="1" stop-opacity=".1"/>
   </linearGradient>
   <mask id="a">
-    <rect width="90" height="20" rx="3" fill="#fff"/>
+    <rect width="86" height="20" rx="3" fill="#fff"/>
   </mask>
   <g mask="url(#a)">
     <path fill="#555" d="M0 0h33v20H0z"/>
     <path fill="#e05d44" d="M33 0h100v20H33z"/>
-    <path fill="url(#b)" d="M0 0h90v20H0z"/>
+    <path fill="url(#b)" d="M0 0h86v20H0z"/>
   </g>
   <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
     <text x="16.5" y="15" fill="#010101" fill-opacity=".3">esm</text>
     <text x="16.5" y="14">esm</text>
-    <text x="59" y="15" fill="#010101" fill-opacity=".3">13.80 kB</text>
-    <text x="59" y="14">13.80 kB</text>
+    <text x="59" y="15" fill="#010101" fill-opacity=".3">3.66 kB</text>
+    <text x="59" y="14">3.66 kB</text>
   </g>
 </svg>

--- a/docs/images/esm.svg
+++ b/docs/images/esm.svg
@@ -1,20 +1,21 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="82" height="20">
-  <linearGradient id="b" x2="0" y2="100%">
-    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
-    <stop offset="1" stop-opacity=".1"/>
-  </linearGradient>
-  <mask id="a">
-    <rect width="82" height="20" rx="3" fill="#fff"/>
-  </mask>
-  <g mask="url(#a)">
-    <path fill="#555" d="M0 0h33v20H0z"/>
-    <path fill="#e05d44" d="M33 0h49v20H33z"/>
-    <path fill="url(#b)" d="M0 0h82v20H0z"/>
-  </g>
-  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
-    <text x="16.5" y="15" fill="#010101" fill-opacity=".3">esm</text>
-    <text x="16.5" y="14">esm</text>
-    <text x="56.5" y="15" fill="#010101" fill-opacity=".3">3.66 kB</text>
-    <text x="56.5" y="14">3.66 kB</text>
-  </g>
-</svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="86" height="20">
+    <linearGradient id="b" x2="0" y2="100%">
+      <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+      <stop offset="1" stop-opacity=".1"/>
+    </linearGradient>
+    <mask id="a">
+      <rect width="86" height="20" rx="3" fill="#fff"/>
+    </mask>
+    <g mask="url(#a)">
+      <path fill="#555" d="M0 0h33v20H0z"/>
+      <path fill="#e05d44" d="M33 0h100v20H33z"/>
+      <path fill="url(#b)" d="M0 0h86v20H0z"/>
+    </g>
+    <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+      <text x="16.5" y="15" fill="#010101" fill-opacity=".3">esm</text>
+      <text x="16.5" y="14">esm</text>
+      <text x="59" y="15" fill="#010101" fill-opacity=".3">3.66 kB</text>
+      <text x="59" y="14">3.66 kB</text>
+    </g>
+  </svg>
+  

--- a/docs/images/esm.svg
+++ b/docs/images/esm.svg
@@ -1,21 +1,20 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="86" height="20">
-    <linearGradient id="b" x2="0" y2="100%">
-      <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
-      <stop offset="1" stop-opacity=".1"/>
-    </linearGradient>
-    <mask id="a">
-      <rect width="86" height="20" rx="3" fill="#fff"/>
-    </mask>
-    <g mask="url(#a)">
-      <path fill="#555" d="M0 0h33v20H0z"/>
-      <path fill="#e05d44" d="M33 0h100v20H33z"/>
-      <path fill="url(#b)" d="M0 0h86v20H0z"/>
-    </g>
-    <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
-      <text x="16.5" y="15" fill="#010101" fill-opacity=".3">esm</text>
-      <text x="16.5" y="14">esm</text>
-      <text x="59" y="15" fill="#010101" fill-opacity=".3">3.66 kB</text>
-      <text x="59" y="14">3.66 kB</text>
-    </g>
-  </svg>
-  
+<svg xmlns="http://www.w3.org/2000/svg" width="90" height="20">
+  <linearGradient id="b" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+  <mask id="a">
+    <rect width="90" height="20" rx="3" fill="#fff"/>
+  </mask>
+  <g mask="url(#a)">
+    <path fill="#555" d="M0 0h33v20H0z"/>
+    <path fill="#e05d44" d="M33 0h100v20H33z"/>
+    <path fill="url(#b)" d="M0 0h90v20H0z"/>
+  </g>
+  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+    <text x="16.5" y="15" fill="#010101" fill-opacity=".3">esm</text>
+    <text x="16.5" y="14">esm</text>
+    <text x="59" y="15" fill="#010101" fill-opacity=".3">13.80 kB</text>
+    <text x="59" y="14">13.80 kB</text>
+  </g>
+</svg>

--- a/docs/images/umd.svg
+++ b/docs/images/umd.svg
@@ -1,21 +1,20 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="90" height="20">
-    <linearGradient id="b" x2="0" y2="100%">
-      <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
-      <stop offset="1" stop-opacity=".1"/>
-    </linearGradient>
-    <mask id="a">
-      <rect width="90" height="20" rx="3" fill="#fff"/>
-    </mask>
-    <g mask="url(#a)">
-      <path fill="#555" d="M0 0h33v20H0z"/>
-      <path fill="#e05d44" d="M33 0h100v20H33z"/>
-      <path fill="url(#b)" d="M0 0h90v20H0z"/>
-    </g>
-    <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
-      <text x="16.5" y="15" fill="#010101" fill-opacity=".3">umd</text>
-      <text x="16.5" y="14">umd</text>
-      <text x="59" y="15" fill="#010101" fill-opacity=".3">13.80 kB</text>
-      <text x="59" y="14">13.80 kB</text>
-    </g>
-  </svg>
-  
+  <linearGradient id="b" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+  <mask id="a">
+    <rect width="90" height="20" rx="3" fill="#fff"/>
+  </mask>
+  <g mask="url(#a)">
+    <path fill="#555" d="M0 0h33v20H0z"/>
+    <path fill="#e05d44" d="M33 0h100v20H33z"/>
+    <path fill="url(#b)" d="M0 0h90v20H0z"/>
+  </g>
+  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+    <text x="16.5" y="15" fill="#010101" fill-opacity=".3">umd</text>
+    <text x="16.5" y="14">umd</text>
+    <text x="59" y="15" fill="#010101" fill-opacity=".3">13.80 kB</text>
+    <text x="59" y="14">13.80 kB</text>
+  </g>
+</svg>

--- a/docs/images/umd.svg
+++ b/docs/images/umd.svg
@@ -1,20 +1,21 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="82" height="20">
-  <linearGradient id="b" x2="0" y2="100%">
-    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
-    <stop offset="1" stop-opacity=".1"/>
-  </linearGradient>
-  <mask id="a">
-    <rect width="82" height="20" rx="3" fill="#fff"/>
-  </mask>
-  <g mask="url(#a)">
-    <path fill="#555" d="M0 0h33v20H0z"/>
-    <path fill="#e05d44" d="M33 0h49v20H33z"/>
-    <path fill="url(#b)" d="M0 0h82v20H0z"/>
-  </g>
-  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
-    <text x="16.5" y="15" fill="#010101" fill-opacity=".3">umd</text>
-    <text x="16.5" y="14">umd</text>
-    <text x="56.5" y="15" fill="#010101" fill-opacity=".3">13.80 kB</text>
-    <text x="56.5" y="14">13.80 kB</text>
-  </g>
-</svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="90" height="20">
+    <linearGradient id="b" x2="0" y2="100%">
+      <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+      <stop offset="1" stop-opacity=".1"/>
+    </linearGradient>
+    <mask id="a">
+      <rect width="90" height="20" rx="3" fill="#fff"/>
+    </mask>
+    <g mask="url(#a)">
+      <path fill="#555" d="M0 0h33v20H0z"/>
+      <path fill="#e05d44" d="M33 0h100v20H33z"/>
+      <path fill="url(#b)" d="M0 0h90v20H0z"/>
+    </g>
+    <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+      <text x="16.5" y="15" fill="#010101" fill-opacity=".3">umd</text>
+      <text x="16.5" y="14">umd</text>
+      <text x="59" y="15" fill="#010101" fill-opacity=".3">13.80 kB</text>
+      <text x="59" y="14">13.80 kB</text>
+    </g>
+  </svg>
+  

--- a/examples/umd-example/index.html
+++ b/examples/umd-example/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <link rel="icon" type="image/png" href="https://raw.githubusercontent.com/Tram-One/tram-logo/master/v3/black_64x64.png" />
-    <script src="https://unpkg.com/tram-one"></script>
+    <script src="https://unpkg.com/tram-one/dist/tram-one.umd.js"></script>
   </head>
   <body>
     <div class="main"></div>
@@ -16,7 +16,7 @@
           <div>
             <h2>UMD Page Example</h2>
             <div>
-              This Page uses the umd hosted on <a href="https://unpkg.com/tram-one">unpkg.com/tram-one</a>
+              This Page uses the umd hosted on <a href="https://unpkg.com/tram-one/dist/tram-one.umd.js">unpkg.com/tram-one</a>
               <br />
               Note: You can find these umd builds in the <a href="https://github.com/Tram-One/tram-one/releases">releases on github</a> and the
               npm release when you run npm install (node_modules/tram-one/dist/tram-one.umd.js)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tram-one",
-  "version": "4.2.0",
+  "version": "5.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "tram-one",
-  "version": "4.2.0",
+  "version": "5.0.0",
   "description": "🚋 Batteries Included View Framework",
-  "main": "dist/tram-one.umd.js",
+  "main": "dist/tram-one.esm.js",
   "module": "dist/tram-one.esm.js",
+  "umd": "dist/tram-one.umd.js",
   "files": [
     "dist/tram-one.esm.js",
     "dist/tram-one.umd.js"


### PR DESCRIPTION
## Summary
Make main export the ES module, that way asserts will be visible when doing initial development. 
## Related Git Issues
- #85 
- https://github.com/Tram-One/tram-one-express/issues/22

## Misc Changes
- updated svg badges to be cleaner
- updated unpkg links to point to umd