### PR TITLE
Handle redundant slashes in routes

### DIFF
--- a/docs/images/esm.svg
+++ b/docs/images/esm.svg
@@ -14,7 +14,7 @@
   <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
     <text x="16.5" y="15" fill="#010101" fill-opacity=".3">esm</text>
     <text x="16.5" y="14">esm</text>
-    <text x="59" y="15" fill="#010101" fill-opacity=".3">3.66 kB</text>
-    <text x="59" y="14">3.66 kB</text>
+    <text x="59" y="15" fill="#010101" fill-opacity=".3">3.91 kB</text>
+    <text x="59" y="14">3.91 kB</text>
   </g>
 </svg>

--- a/docs/images/umd.svg
+++ b/docs/images/umd.svg
@@ -14,7 +14,7 @@
   <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
     <text x="16.5" y="15" fill="#010101" fill-opacity=".3">umd</text>
     <text x="16.5" y="14">umd</text>
-    <text x="59" y="15" fill="#010101" fill-opacity=".3">13.80 kB</text>
-    <text x="59" y="14">13.80 kB</text>
+    <text x="59" y="15" fill="#010101" fill-opacity=".3">13.82 kB</text>
+    <text x="59" y="14">13.82 kB</text>
   </g>
 </svg>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tram-one",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2181,9 +2181,9 @@
       }
     },
     "eslint-config-tram-one": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-tram-one/-/eslint-config-tram-one-1.2.0.tgz",
-      "integrity": "sha512-oGv32neX070SAogsLF5YCUmPGPCwgnHyMDm0pdR0FbdP88pdLAdz/05VEkZZ0CPIe+I+jCikOUO+eaNtqrnSqQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-tram-one/-/eslint-config-tram-one-2.0.0.tgz",
+      "integrity": "sha512-KXtnoRBMb76jfRomvqNt4faMX+TRsB5btIk7G0P1eAIfAqWjVKCe7veyE/3GoX5odtsOQ+7a1RuFGQLSfFl11w==",
       "dev": true
     },
     "eslint-config-xo": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tram-one",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "🚋 Batteries Included View Framework",
   "main": "dist/tram-one.esm.js",
   "module": "dist/tram-one.esm.js",
@@ -56,7 +56,7 @@
   "devDependencies": {
     "buble-loader": "^0.4.1",
     "domino": "^2.0.1",
-    "eslint-config-tram-one": "^1.1.1",
+    "eslint-config-tram-one": "^2.0.0",
     "express": "^4.15.3",
     "inquirer": "^5.1.0",
     "internal-ip": "^1.2.0",

--- a/tests/specs/tram-spec.js
+++ b/tests/specs/tram-spec.js
@@ -151,7 +151,7 @@ const tests = (Tram) => describe('Tram', () => {
         .toEqual(Tram.html()`<div><span><p>grandchild</p></span></div>`.outerHTML)
     })
 
-    it('should handle redundent slashes', () => {
+    it('should handle redundant slashes', () => {
       const app = new Tram()
       const top = (s, a, p, child) => Tram.html()`<div>${child}</div>`
       const child = (s, a, p, child) => Tram.html()`<span>${child}</span>`

--- a/tests/specs/tram-spec.js
+++ b/tests/specs/tram-spec.js
@@ -151,6 +151,20 @@ const tests = (Tram) => describe('Tram', () => {
         .toEqual(Tram.html()`<div><span><p>grandchild</p></span></div>`.outerHTML)
     })
 
+    it('should handle redundent slashes', () => {
+      const app = new Tram()
+      const top = (s, a, p, child) => Tram.html()`<div>${child}</div>`
+      const child = (s, a, p, child) => Tram.html()`<span>${child}</span>`
+      const grandchild = () => Tram.html()`<p>grandchild</p>`
+      app.addRoute('/', top, [
+        Tram.route()('/a/', child, [
+          Tram.route()('/b', grandchild)
+        ])
+      ])
+      expect(app.toString('/a/b'))
+        .toEqual(Tram.html()`<div><span><p>grandchild</p></span></div>`.outerHTML)
+    })
+
     it('should be chainable', () => {
       const app = new Tram()
         .addRoute('/good', successPage)

--- a/tram-one.js
+++ b/tram-one.js
@@ -45,7 +45,8 @@ class Tram {
 
     if (subroutes) {
       subroutes.forEach(subroute => {
-        const newPath = path + subroute.path
+        assert.equal(typeof subroute, 'object', 'Tram-One: subroute should be an object, use Tram.route to make subroutes')
+        const newPath = (path + subroute.path).split('//').join('/')
         const newPage = (store, actions, params, resolvedSubroute) => {
           const newSubroute = subroute.component(store, actions, params, resolvedSubroute)
           return page(store, actions, params, newSubroute)
@@ -75,6 +76,8 @@ class Tram {
   }
 
   mount(selector, pathName, store, actions) {
+    assert.ok(selector !== undefined, 'Tram-One: selector should be a DOM element or CSS selection string')
+
     const target = (typeof selector) === 'string' ? document.querySelector(selector) : selector
     if (target === null) {
       console.warn('Tram-One: could not find target, is the element on the page yet?')


### PR DESCRIPTION
## Summary
Originally nested routes with redundant `/` would cause conflicts in resolving the route. Since `//` is never going to be valid, it's safe to reduce instances of these to `/`.

### before
```javascript
app.addRoute('/', require('./pages/Chrome'), [
  route('about', require('./pages/HomePage')),
  route('images/:albumPage', require('./pages/ImageSetPage')),
  route('404', require('./pages/404'))
])
```

### after
```javascript
app.addRoute('/', require('./pages/Chrome'), [
  route('/about', require('./pages/HomePage')),
  route('/images/:albumPage', require('./pages/ImageSetPage')),
  route('/404', require('./pages/404'))
])
```
## Tests
- [x] Test has been written to capture new functionality

## Misc Changes
- bump eslint version