### PR TITLE
Add Hover-Battery

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ For Routing:
 
 For State Management:
   - [hover-engine](https://github.com/Tram-One/hover-engine)
+  - [hover-battery](https://github.com/Tram-One/hover-battery)
 
 While not used in this project, Tram-One is heavily inspired by the
 [choo](https://github.com/choojs/choo) view framework.
@@ -409,9 +410,8 @@ app.addActions({votes: voteActions})
 _Reference: [hover-engine](https://github.com/Tram-One/hover-engine)_
 
 `app.addListener` adds a function that triggers on every action call. This can
-be used to save state in localstorage, or to debug the state of the store as
-actions are called. This should not be used to update the DOM, only trigger
-side-effects.
+be used to debug the state of the store as actions are called. This should not
+be used to update the DOM, only trigger side-effects.
 
 It takes in one argument, a [`listener`](#listener).
 

--- a/README.md
+++ b/README.md
@@ -348,9 +348,10 @@ app.addRoute('/', home)
 #### Constructor Options
 Below are a list of options that can be set when making a Tram-One app.
 
-|option        |description                                             |default value|type   |
-|--------------|--------------------------------------------------------|-------------|-------|
-|`defaultRoute`|if we fail to find a route, which route we should render|'/404'       |string |
+|option        |description                                             |default value |type   |
+|--------------|--------------------------------------------------------|--------------|-------|
+|`defaultRoute`|if we fail to find a route, which route we should render|'/404'        |string |
+|`webStorage`  |where to persist the store between page loads           |sessionStorage|object |
 
 ### App Functions
 The following functions should be called on an instance of a Tram-One app (see

--- a/docs/images/esm.svg
+++ b/docs/images/esm.svg
@@ -14,7 +14,7 @@
   <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
     <text x="16.5" y="15" fill="#010101" fill-opacity=".3">esm</text>
     <text x="16.5" y="14">esm</text>
-    <text x="59" y="15" fill="#010101" fill-opacity=".3">4.22 kB</text>
-    <text x="59" y="14">4.22 kB</text>
+    <text x="59" y="15" fill="#010101" fill-opacity=".3">4.29 kB</text>
+    <text x="59" y="14">4.29 kB</text>
   </g>
 </svg>

--- a/docs/images/esm.svg
+++ b/docs/images/esm.svg
@@ -14,7 +14,7 @@
   <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
     <text x="16.5" y="15" fill="#010101" fill-opacity=".3">esm</text>
     <text x="16.5" y="14">esm</text>
-    <text x="59" y="15" fill="#010101" fill-opacity=".3">3.91 kB</text>
-    <text x="59" y="14">3.91 kB</text>
+    <text x="59" y="15" fill="#010101" fill-opacity=".3">4.22 kB</text>
+    <text x="59" y="14">4.22 kB</text>
   </g>
 </svg>

--- a/docs/images/umd.svg
+++ b/docs/images/umd.svg
@@ -14,7 +14,7 @@
   <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
     <text x="16.5" y="15" fill="#010101" fill-opacity=".3">umd</text>
     <text x="16.5" y="14">umd</text>
-    <text x="59" y="15" fill="#010101" fill-opacity=".3">13.82 kB</text>
-    <text x="59" y="14">13.82 kB</text>
+    <text x="59" y="15" fill="#010101" fill-opacity=".3">14.40 kB</text>
+    <text x="59" y="14">14.40 kB</text>
   </g>
 </svg>

--- a/docs/images/umd.svg
+++ b/docs/images/umd.svg
@@ -14,7 +14,7 @@
   <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
     <text x="16.5" y="15" fill="#010101" fill-opacity=".3">umd</text>
     <text x="16.5" y="14">umd</text>
-    <text x="59" y="15" fill="#010101" fill-opacity=".3">14.40 kB</text>
-    <text x="59" y="14">14.40 kB</text>
+    <text x="59" y="15" fill="#010101" fill-opacity=".3">14.44 kB</text>
+    <text x="59" y="14">14.44 kB</text>
   </g>
 </svg>

--- a/examples/using-listeners/index.js
+++ b/examples/using-listeners/index.js
@@ -3,7 +3,7 @@ const app = new Tram()
 const html = Tram.html()
 
 const countActions = {
-  init: () => parseInt(localStorage.count, 10) ? parseInt(localStorage.count, 10) : 0,
+  init: () => 0,
   up: (count) => count + 1,
   down: (count) => count - 1
 }
@@ -20,7 +20,9 @@ const clicker = (store, actions) => {
     <div>
       You can use Tram-One's
       <a href="https://github.com/JRJurman/hover-engine">Hover-Engine</a>
-      to listen for state change, and debug or save whatever the current state is.
+      to listen for state changes and debug whatever the current state is.
+
+      Open the console window to see logging.
       <br />
       <div>
         Current Value: ${store.counter}
@@ -38,11 +40,6 @@ const clicker = (store, actions) => {
 // log what is happening on the store
 app.addListener((store, actions, actionName) => {
   console.log(actionName, '->', store.counter)
-})
-
-// save what is happening in localstorage
-app.addListener(store => {
-  localStorage.count = store.counter
 })
 
 app.addActions({counter: countActions})

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tram-one",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4395,6 +4395,11 @@
       "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
       "dev": true
     },
+    "hover-battery": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hover-battery/-/hover-battery-1.0.0.tgz",
+      "integrity": "sha512-vR3w2lPGdONP9LWi1sAZQVw+OLloJ/I6Nbnpm9k4uy1Ku95uZA3YxZO2OLIAJMqupqCsDY3H9L5zhUi1C7uTNw=="
+    },
     "hover-engine": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/hover-engine/-/hover-engine-1.3.1.tgz",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   "license": "MIT",
   "dependencies": {
     "belit": "^4.0.0",
+    "hover-battery": "^1.0.0",
     "hover-engine": "^1.3.0",
     "hyperx": "Tram-One/hyperx",
     "nanomorph": "^5.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tram-one",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "🚋 Batteries Included View Framework",
   "main": "dist/tram-one.esm.js",
   "module": "dist/tram-one.esm.js",

--- a/tests/specs/tram-spec.js
+++ b/tests/specs/tram-spec.js
@@ -40,7 +40,7 @@ const tests = (Tram) => describe('Tram', () => {
       expect(app.toString('/')).toEqual(successPage().outerHTML)
     })
 
-    it('should not always go to the default', () => {
+    it('should not always go to the default route', () => {
       const app = new Tram()
 
       app.addRoute('/404', errorPage)
@@ -193,6 +193,7 @@ const tests = (Tram) => describe('Tram', () => {
       const childDiv = document.getElementById(containerId)
       window.history.pushState = originalPushState
       window.removeEventListener('popstate', popevent)
+      sessionStorage.clear()
       app.mount = () => {}
       document.body.removeChild(childDiv)
     })
@@ -237,6 +238,42 @@ const tests = (Tram) => describe('Tram', () => {
       }
       window.addEventListener('popstate', popevent)
       window.history.back()
+    })
+
+    it('should update default webStorage', () => {
+      app = new Tram()
+
+      app.addActions({counter: counterActions})
+      app.addRoute(testemPath, queryableCounterPage)
+      app.start(`#${containerId}`)
+      app.engine.actions.add()
+
+      expect(sessionStorage.getItem('counter')).toEqual('3')
+    })
+
+    it('should update defined webStorage', () => {
+      const mockStorage = {}
+      app = new Tram({webStorage: mockStorage})
+
+      app.addActions({counter: counterActions})
+      app.addRoute(testemPath, queryableCounterPage)
+      app.start(`#${containerId}`)
+      app.engine.actions.add()
+
+      expect(sessionStorage.getItem('counter')).toEqual(null)
+      expect(mockStorage.counter).toEqual('3')
+    })
+
+    it('should pull from webStorage', () => {
+      sessionStorage.setItem('counter', 8)
+      app = new Tram()
+
+      app.addActions({counter: counterActions})
+      app.addRoute(testemPath, queryableCounterPage)
+      app.start(`#${containerId}`)
+
+      const mountedTargetFirst = document.querySelector(queryableSelector)
+      expect(mountedTargetFirst.innerHTML).toEqual('8')
     })
 
     it('should take in a path', () => {

--- a/tram-one.js
+++ b/tram-one.js
@@ -16,7 +16,7 @@ class Tram {
     options = options || {}
     this.defaultRoute = options.defaultRoute || '/404'
 
-    const webSession = (typeof sessionStorage === undefined) ? {} : sessionStorage
+    const webSession = (typeof sessionStorage === 'object') ? sessionStorage : {}
     this.webStorage = options.webStorage || webSession
 
     this.router = rlite()

--- a/tram-one.js
+++ b/tram-one.js
@@ -1,5 +1,6 @@
 const assert = require('assert')
 const belit = require('belit')
+const battery = require('hover-battery')
 const HoverEngine = require('hover-engine')
 const morph = require('nanomorph')
 const rlite = require('rlite-router')
@@ -14,6 +15,9 @@ class Tram {
 
     options = options || {}
     this.defaultRoute = options.defaultRoute || '/404'
+
+    const webSession = (typeof sessionStorage === undefined) ? {} : sessionStorage
+    this.webStorage = options.webStorage || webSession
 
     this.router = rlite()
     this.internalRouter = {}
@@ -65,6 +69,9 @@ class Tram {
     this.engine.addListener((store, actions) => {
       this.mount(selector, pathName, store, actions)
     })
+
+    this.engine.addActions(battery(this.webStorage).actions)
+    this.engine.addListener(battery(this.webStorage).listener)
 
     urlListener(() => {
       this.mount(selector, pathName)

--- a/tram-one.js
+++ b/tram-one.js
@@ -17,7 +17,7 @@ class Tram {
     this.defaultRoute = options.defaultRoute || '/404'
 
     const webSession = (typeof sessionStorage === 'object') ? sessionStorage : {}
-    this.webStorage = options.webStorage || webSession
+    this.webStorage = (options.webStorage === undefined) ? webSession : options.webStorage
 
     this.router = rlite()
     this.internalRouter = {}
@@ -70,8 +70,10 @@ class Tram {
       this.mount(selector, pathName, store, actions)
     })
 
-    this.engine.addActions(battery(this.webStorage).actions)
-    this.engine.addListener(battery(this.webStorage).listener)
+    if (this.webStorage) {
+      this.engine.addActions(battery(this.webStorage).actions)
+      this.engine.addListener(battery(this.webStorage).listener)
+    }
 
     urlListener(() => {
       this.mount(selector, pathName)


### PR DESCRIPTION
## Summary
Add hover-battery, to tram-one project. This will allow projects by default to keep session between page reloads.

By default we'll save to `sessionStorage`. However we'll add this as a variable that can be set when calling the constructor.

## Usage
```javascript
const app = new Tram({webStorage: localStroage})
```

## New Stuff
- add `hover-battery` to project
- new option in constructor, `webStorage`, defaults to `sessionStorage`
- tests around `webStorage` option, as the default and with a mockStorage object

## Changes
- Removed references to using `addListener` to save to localStorage
- Bump minor: version 5.2.0
