### PR TITLE
Make Default WebStorage undefined

### DIFF
--- a/docs/images/esm.svg
+++ b/docs/images/esm.svg
@@ -14,7 +14,7 @@
   <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
     <text x="16.5" y="15" fill="#010101" fill-opacity=".3">esm</text>
     <text x="16.5" y="14">esm</text>
-    <text x="59" y="15" fill="#010101" fill-opacity=".3">4.29 kB</text>
-    <text x="59" y="14">4.29 kB</text>
+    <text x="59" y="15" fill="#010101" fill-opacity=".3">4.16 kB</text>
+    <text x="59" y="14">4.16 kB</text>
   </g>
 </svg>

--- a/docs/images/umd.svg
+++ b/docs/images/umd.svg
@@ -14,7 +14,7 @@
   <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
     <text x="16.5" y="15" fill="#010101" fill-opacity=".3">umd</text>
     <text x="16.5" y="14">umd</text>
-    <text x="59" y="15" fill="#010101" fill-opacity=".3">13.39 kB</text>
-    <text x="59" y="14">13.39 kB</text>
+    <text x="59" y="15" fill="#010101" fill-opacity=".3">13.32 kB</text>
+    <text x="59" y="14">13.32 kB</text>
   </g>
 </svg>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tram-one",
-  "version": "5.2.1",
+  "version": "6.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -690,6 +690,89 @@
       "dev": true,
       "requires": {
         "pako": "1.0.6"
+      }
+    },
+    "buble": {
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/buble/-/buble-0.19.3.tgz",
+      "integrity": "sha512-3B0Lcy2u6x6km0BqTz/FS3UnrOJlnIlBWsyjvtqzdtmWkqiS0+Sg4hc6L9Mmm63hZKTACpYS9vUeIoKSi1vcrQ==",
+      "dev": true,
+      "requires": {
+        "acorn": "5.5.3",
+        "acorn-dynamic-import": "3.0.0",
+        "acorn-jsx": "4.1.1",
+        "chalk": "2.4.1",
+        "magic-string": "0.22.5",
+        "minimist": "1.2.0",
+        "os-homedir": "1.0.2",
+        "vlq": "1.0.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "5.5.3",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
+          "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
+          "dev": true
+        },
+        "acorn-dynamic-import": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-3.0.0.tgz",
+          "integrity": "sha512-zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg==",
+          "dev": true,
+          "requires": {
+            "acorn": "5.5.3"
+          }
+        },
+        "acorn-jsx": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-4.1.1.tgz",
+          "integrity": "sha512-JY+iV6r+cO21KtntVvFkD+iqjtdpRUpGqKWgfkCdZq1R+kbreEl8EcdcJR4SmiIgsIQT33s6QzheQ9a275Q8xw==",
+          "dev": true,
+          "requires": {
+            "acorn": "5.5.3"
+          }
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.4.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        },
+        "vlq": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/vlq/-/vlq-1.0.0.tgz",
+          "integrity": "sha512-o3WmXySo+oI5thgqr7Qy8uBkT/v9Zr+sRyrh1lr8aWPUkgDWdWt4Nae2WKBrLsocgE8BuWWD0jLc+VW8LeU+2g==",
+          "dev": true
+        }
       }
     },
     "buble-loader": {
@@ -5769,6 +5852,15 @@
       "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.0.tgz",
       "integrity": "sha1-tlul/LNJopkkyOMz98alVi8uSEI=",
       "dev": true
+    },
+    "magic-string": {
+      "version": "0.22.5",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz",
+      "integrity": "sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==",
+      "dev": true,
+      "requires": {
+        "vlq": "0.2.3"
+      }
     },
     "make-dir": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tram-one",
-  "version": "5.2.1",
+  "version": "6.0.0",
   "description": "🚋 Batteries Included View Framework",
   "main": "dist/tram-one.esm.js",
   "module": "dist/tram-one.esm.js",
@@ -55,6 +55,7 @@
     "url-listener": "^2.0.0"
   },
   "devDependencies": {
+    "buble": "^0.19.3",
     "buble-loader": "^0.5.0",
     "domino": "^2.0.1",
     "eslint-config-tram-one": "^2.0.0",

--- a/tests/specs/tram-spec.js
+++ b/tests/specs/tram-spec.js
@@ -240,7 +240,7 @@ const tests = (Tram) => describe('Tram', () => {
       window.history.back()
     })
 
-    it('should update default webStorage', () => {
+    it('should not write to undefined webStorage', () => {
       app = new Tram()
 
       app.addActions({counter: counterActions})
@@ -248,7 +248,8 @@ const tests = (Tram) => describe('Tram', () => {
       app.start(`#${containerId}`)
       app.engine.actions.add()
 
-      expect(sessionStorage.getItem('counter')).toEqual('3')
+      expect(sessionStorage.getItem('counter')).toBeNull()
+      expect(localStorage.getItem('counter')).toBeNull()
     })
 
     it('should update defined webStorage', () => {
@@ -264,9 +265,9 @@ const tests = (Tram) => describe('Tram', () => {
       expect(mockStorage.counter).toEqual('3')
     })
 
-    it('should pull from webStorage', () => {
+    it('should pull from defined webStorage', () => {
       sessionStorage.setItem('counter', 8)
-      app = new Tram()
+      app = new Tram({webStorage: sessionStorage})
 
       app.addActions({counter: counterActions})
       app.addRoute(testemPath, queryableCounterPage)

--- a/tram-one.js
+++ b/tram-one.js
@@ -15,9 +15,7 @@ class Tram {
 
     options = options || {}
     this.defaultRoute = options.defaultRoute || '/404'
-
-    const webSession = (typeof sessionStorage === 'object') ? sessionStorage : {}
-    this.webStorage = (options.webStorage === undefined) ? webSession : options.webStorage
+    this.webStorage = options.webStorage
 
     this.router = rlite()
     this.internalRouter = {}


### PR DESCRIPTION
## Summary

After working with `sessionStorage` as the default `webStorage`, it became painfully obvious that `sessionStorage` as the default is a bad idea. It makes debugging and playing around with different state options incredibly difficult.

Making the default should effectively make development the same as not having hover-battery at all, and it's still easy to enable webStorage with the constructor option.

Potentially, we could remove the package altogether, but I like the idea of having this quickly available (like state management, you might not need it, but it's there for you).

## Bump Major (v6)
We are bumping major because we have made a change to the defaults, which may be unexpected to users with unchanged configurations.