### PR TITLE
SafeParse with new version of Hover-Battery

### DIFF
--- a/docs/images/umd.svg
+++ b/docs/images/umd.svg
@@ -14,7 +14,7 @@
   <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
     <text x="16.5" y="15" fill="#010101" fill-opacity=".3">umd</text>
     <text x="16.5" y="14">umd</text>
-    <text x="59" y="15" fill="#010101" fill-opacity=".3">13.32 kB</text>
-    <text x="59" y="14">13.32 kB</text>
+    <text x="59" y="15" fill="#010101" fill-opacity=".3">13.42 kB</text>
+    <text x="59" y="14">13.42 kB</text>
   </g>
 </svg>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tram-one",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4453,9 +4453,9 @@
       "dev": true
     },
     "hover-battery": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/hover-battery/-/hover-battery-1.0.0.tgz",
-      "integrity": "sha512-vR3w2lPGdONP9LWi1sAZQVw+OLloJ/I6Nbnpm9k4uy1Ku95uZA3YxZO2OLIAJMqupqCsDY3H9L5zhUi1C7uTNw=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/hover-battery/-/hover-battery-1.1.0.tgz",
+      "integrity": "sha512-+9c+uK5vdtoD9I8y2JFwcac+nifShm7XUoO9qVYPMNzULQcQZNilwvHfxz4jhWzov4weuW2o1ek8Cq0mH9K/cQ=="
     },
     "hover-engine": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tram-one",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "description": "🚋 Batteries Included View Framework",
   "main": "dist/tram-one.esm.js",
   "module": "dist/tram-one.esm.js",
@@ -46,7 +46,7 @@
   "license": "MIT",
   "dependencies": {
     "belit": "^4.0.0",
-    "hover-battery": "^1.0.0",
+    "hover-battery": "^1.1.0",
     "hover-engine": "^2.0.2",
     "hyperx": "Tram-One/hyperx",
     "nanomorph": "^5.1.2",


### PR DESCRIPTION
## Summary

Update to include changes in https://github.com/Tram-One/hover-battery/pull/2

