### PR TITLE
Server Side Rendering & Hydration Example

### DIFF
--- a/examples/ssr-example/README.md
+++ b/examples/ssr-example/README.md
@@ -1,0 +1,5 @@
+# Server Side Rendering and Hydration Example
+
+To run this example, do the following from the `ssr-example` directory:
+1. `npx webpack`
+2. `node server.js`

--- a/examples/ssr-example/index.js
+++ b/examples/ssr-example/index.js
@@ -13,6 +13,7 @@ const home = () => html`
   <div>
     <h1>This is the Home Page</h1>
     <div> This is rendered on a server, and then served up to you! </div>
+    <div> If you have JS disabled, this page will still work.</div>
     <div> We also have a number page here: <a href="/number">/number</a> </div>
   </div>
 `
@@ -27,7 +28,10 @@ const num = (state, actions) => {
     <div>
       <h1>This is a Number Page</h1>
       <div> This is rendered on a server, and then served up to you! </div>
+      <div> If you have JS disabled, this page will still work.</div>
       <div> We can even take in stuff from the server, like this number: ${state.number} </div>
+      <div> If you have JS enabled, we've hydrated the app with a bundled JS script tag, </div>
+      <div> so you can do everything you normally could on a JS rich app. </div>
       <button onclick=${onNewNumber}> Generate New Number </button>
     </div>
   `

--- a/examples/ssr-example/index.js
+++ b/examples/ssr-example/index.js
@@ -5,16 +5,22 @@ const home = () => html`
   <div>
     <h1>This is the Home Page</h1>
     <div> This is rendered on a server, and then served up to you! </div>
-    <div> We also have a number page here: <a href="/num">/num</a> </div>
+    <div> We also have a number page here: <a href="/number">/number</a> </div>
   </div>
 `
-const num = (state) => html`
-  <div>
-    <h1>This is a Number Page</h1>
-    <div> This is rendered on a server, and then served up to you! </div>
-    <div> We can even take in stuff from the server, like this number: ${state.number} </div>
-  </div>
-`
+const num = (state, actions) => {
+  const onNewNumber = () => {
+    actions.newNumber()
+  }
+  return html`
+    <div>
+      <h1>This is a Number Page</h1>
+      <div> This is rendered on a server, and then served up to you! </div>
+      <div> We can even take in stuff from the server, like this number: ${state.number} </div>
+      <button onclick=${onNewNumber}> Generate New Number </button>
+    </div>
+  `
+}
 
 app.addRoute('/', home)
 app.addRoute('/number', num)

--- a/examples/ssr-example/index.js
+++ b/examples/ssr-example/index.js
@@ -1,6 +1,14 @@
 const Tram = require('../../tram-one')
 const app = new Tram()
 const html = Tram.html()
+
+const numberActions = {
+  init: () => (Math.random() * 100).toFixed(2),
+  newNumber: () => (Math.random() * 100).toFixed(2)
+}
+
+app.addActions({number: numberActions})
+
 const home = () => html`
   <div>
     <h1>This is the Home Page</h1>
@@ -8,6 +16,9 @@ const home = () => html`
     <div> We also have a number page here: <a href="/number">/number</a> </div>
   </div>
 `
+
+app.addRoute('/', home)
+
 const num = (state, actions) => {
   const onNewNumber = () => {
     actions.newNumber()
@@ -22,7 +33,6 @@ const num = (state, actions) => {
   `
 }
 
-app.addRoute('/', home)
 app.addRoute('/number', num)
 
 module.exports = app

--- a/examples/ssr-example/main.js
+++ b/examples/ssr-example/main.js
@@ -1,0 +1,7 @@
+const app = require('./index.js')
+const numberActions = {
+  init: () => (Math.random() * 100).toFixed(2),
+  newNumber: () => (Math.random() * 100).toFixed(2)
+}
+app.addActions({number: numberActions})
+app.start('.main')

--- a/examples/ssr-example/main.js
+++ b/examples/ssr-example/main.js
@@ -1,7 +1,2 @@
 const app = require('./index.js')
-const numberActions = {
-  init: () => (Math.random() * 100).toFixed(2),
-  newNumber: () => (Math.random() * 100).toFixed(2)
-}
-app.addActions({number: numberActions})
 app.start('.main')

--- a/examples/ssr-example/server.js
+++ b/examples/ssr-example/server.js
@@ -18,7 +18,8 @@ server.use(express.static('dist'))
 // serve the home page, with no bundle
 // because it needs no hydration
 server.get('/', (req, res) => {
-  res.send(app.toString('/'))
+  const page = app.toString('/')
+  res.send(page)
 })
 
 // serve the number page with a bundle

--- a/examples/ssr-example/server.js
+++ b/examples/ssr-example/server.js
@@ -4,13 +4,29 @@ const express = require('express')
 const server = express()
 const app = require('./index')
 
+const pageWithBundle = (page, src) => `
+  <html>
+    <head></head>
+    <body>
+      <div class="main">
+        ${page}
+      </div>
+      <script src="${src}"></script>
+    </body>
+  </html>
+`
+
+server.use(express.static('dist'))
+
 server.get('/', (req, res) => {
   res.send(app.toString('/'))
 })
 
-server.get('/num', (req, res) => {
-  const number = Math.random() * 10
-  res.send(app.toString('/number', {number}))
+server.get('/number', (req, res) => {
+  const number = (Math.random() * 100).toFixed(2)
+  const page = app.toString('/number', {number})
+  res.set('Content-Type', 'text/html')
+  res.send(pageWithBundle(page, '/bundle.js'))
 })
 
 server.listen(5000, () => {

--- a/examples/ssr-example/server.js
+++ b/examples/ssr-example/server.js
@@ -4,31 +4,31 @@ const express = require('express')
 const server = express()
 const app = require('./index')
 
+// page template so we can hydrate the page
+// with javascript after the initial load
 const pageWithBundle = (page, src) => `
-  <html>
-    <head></head>
-    <body>
-      <div class="main">
-        ${page}
-      </div>
-      <script src="${src}"></script>
-    </body>
-  </html>
+  <div class="main">
+    ${page}
+  </div>
+  <script src="${src}"></script>
 `
 
 server.use(express.static('dist'))
 
+// serve the home page, with no bundle
+// because it needs no hydration
 server.get('/', (req, res) => {
   res.send(app.toString('/'))
 })
 
+// serve the number page with a bundle
+// so that we can use js on the page
 server.get('/number', (req, res) => {
   const number = (Math.random() * 100).toFixed(2)
   const page = app.toString('/number', {number})
-  res.set('Content-Type', 'text/html')
   res.send(pageWithBundle(page, '/bundle.js'))
 })
 
 server.listen(5000, () => {
-  console.log('ssr express server running on port 5000!')
+  console.log('ssr express server running on http://localhost:5000')
 })

--- a/examples/ssr-example/webpack.config.js
+++ b/examples/ssr-example/webpack.config.js
@@ -1,0 +1,12 @@
+const path = require('path')
+
+module.exports = {
+  entry: './main.js',
+  externals: {
+    domino: 'domino'
+  },
+  output: {
+    filename: 'bundle.js',
+    path: path.resolve(__dirname, 'dist')
+  }
+}


### PR DESCRIPTION
## Summary

Previously, for our Server Side Rendering (SSR) example, we could only render the page without javascript. The example has been updated to include a script tag pointing to a webpack build, which should "hydrate" the app with javascript on page load.

Resolves #35 