### PR TITLE
Allow Default Subroutes

### DIFF
--- a/docs/images/esm.svg
+++ b/docs/images/esm.svg
@@ -14,7 +14,7 @@
   <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
     <text x="16.5" y="15" fill="#010101" fill-opacity=".3">esm</text>
     <text x="16.5" y="14">esm</text>
-    <text x="59" y="15" fill="#010101" fill-opacity=".3">9.48 kB</text>
-    <text x="59" y="14">9.48 kB</text>
+    <text x="59" y="15" fill="#010101" fill-opacity=".3">9.83 kB</text>
+    <text x="59" y="14">9.83 kB</text>
   </g>
 </svg>

--- a/docs/images/umd.svg
+++ b/docs/images/umd.svg
@@ -14,7 +14,7 @@
   <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
     <text x="16.5" y="15" fill="#010101" fill-opacity=".3">umd</text>
     <text x="16.5" y="14">umd</text>
-    <text x="59" y="15" fill="#010101" fill-opacity=".3">11.87 kB</text>
-    <text x="59" y="14">11.87 kB</text>
+    <text x="59" y="15" fill="#010101" fill-opacity=".3">11.98 kB</text>
+    <text x="59" y="14">11.98 kB</text>
   </g>
 </svg>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tram-one",
-  "version": "7.1.0",
+  "version": "7.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tram-one",
-  "version": "7.1.0",
+  "version": "7.2.0",
   "description": "🚋 Batteries Included View Framework",
   "main": "dist/tram-one.esm.js",
   "module": "dist/tram-one.esm.js",

--- a/tests/specs/tram-spec.js
+++ b/tests/specs/tram-spec.js
@@ -156,6 +156,17 @@ module.exports = (Tram, isBrowser, testemPath, document) => describe('Tram', () 
         .toEqual(Tram.html()`<div><span><p>grandchild</p></span></div>`.outerHTML)
     })
 
+    it('should inject child on default route (if using just slashes)', () => {
+      const app = new Tram()
+      const top = (s, a, p, child) => Tram.html()`<div>${child}</div>`
+      const child = () => Tram.html()`<span>child</span>`
+      app.addRoute('/', top, [
+        Tram.route()('/', child)
+      ])
+      expect(app.toString('/'))
+        .toEqual(Tram.html()`<div><span>child</span></div>`.outerHTML)
+    })
+
     it('should be chainable', () => {
       const app = new Tram()
         .addRoute('/good', successPage)

--- a/tests/testem.html
+++ b/tests/testem.html
@@ -3,7 +3,7 @@
 <head>
   <title>Test'em</title>
   <link rel="icon" type="image/png" href="tram-car.png" />
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jasmine/2.6.4/jasmine.min.css"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jasmine/2.6.4/jasmine.min.css" />
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jasmine/2.6.4/jasmine.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jasmine/2.6.4/jasmine-html.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jasmine/2.6.4/boot.min.js"></script>

--- a/tram-one.js
+++ b/tram-one.js
@@ -107,7 +107,7 @@ class Tram {
     // this is important because empty subroutes will match their parent
     if (this.internalRouter[path]) {
       console.warn(`Tram-One: path ${path} already exists (this is fine if using empty subroutes)`)
-      return
+      return this
     }
     // update our internal router, and if this happens to be the last call update the rlite router
     this.internalRouter[path] = (params) => (store, actions) => page(store, actions, params)

--- a/tram-one.js
+++ b/tram-one.js
@@ -103,6 +103,12 @@ class Tram {
       })
     }
 
+    // don't overwrite a route if one already exists
+    // this is important because empty subroutes will match their parent
+    if (this.internalRouter[path]) {
+      console.warn(`Tram-One: path ${path} already exists (this is fine if using empty subroutes)`)
+      return
+    }
     // update our internal router, and if this happens to be the last call update the rlite router
     this.internalRouter[path] = (params) => (store, actions) => page(store, actions, params)
     this.router = rlite(this.internalRouter[this.defaultRoute], this.internalRouter)


### PR DESCRIPTION
## Summary

In the past, it was non trivial to have a default child for a route when using subroutes. This is because if you defined a child at `/` and a parent at `/`, the child would be assigned in the router first, and then replaced by the parent definition.
```javascript
app.addRoute('/', require('./pages/wrapper'), [ // assigned second
  route('/', require('./pages/home')), // assigned first, replaced by /pages/wrapper
  route('/404', require('./pages/404')),
  route('/privacy', require('./pages/privacy')),
  route('/opensource', require('./pages/opensource')),
])

app.toString('/')  // => renders /pages/wrapper
```

This PR allows the above to be written and processed in the correct order.

```javascript
app.addRoute('/', require('./pages/wrapper'), [ // not assigned
  route('/', require('./pages/home')), // assigned first
  route('/404', require('./pages/404')),
  route('/privacy', require('./pages/privacy')),
  route('/opensource', require('./pages/opensource')),
])

app.toString('/')  // => renders /pages/home under pages/wrapper
```