### PR TITLE
render-tracker and tram-one tests

### DIFF
--- a/docs/badges/cjs.svg
+++ b/docs/badges/cjs.svg
@@ -14,7 +14,7 @@
   <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
     <text x="16.5" y="15" fill="#010101" fill-opacity=".3">cjs</text>
     <text x="16.5" y="14">cjs</text>
-    <text x="59" y="15" fill="#010101" fill-opacity=".3">28.25 kB</text>
-    <text x="59" y="14">28.25 kB</text>
+    <text x="59" y="15" fill="#010101" fill-opacity=".3">30.17 kB</text>
+    <text x="59" y="14">30.17 kB</text>
   </g>
 </svg>

--- a/docs/badges/umd.svg
+++ b/docs/badges/umd.svg
@@ -14,7 +14,7 @@
   <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
     <text x="16.5" y="15" fill="#010101" fill-opacity=".3">umd</text>
     <text x="16.5" y="14">umd</text>
-    <text x="59" y="15" fill="#010101" fill-opacity=".3">45.72 kB</text>
-    <text x="59" y="14">45.72 kB</text>
+    <text x="59" y="15" fill="#010101" fill-opacity=".3">46.22 kB</text>
+    <text x="59" y="14">46.22 kB</text>
   </g>
 </svg>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tram-one",
-  "version": "8.0.2",
+  "version": "8.0.3",
   "description": "🚋 Batteries Included View Framework",
   "main": "dist/tram-one.cjs.js",
   "commonjs": "dist/tram-one.cjs.js",

--- a/src/engine-names/index.js
+++ b/src/engine-names/index.js
@@ -10,5 +10,6 @@ module.exports = {
   TRAM_HOOK_KEY: 'tram-hook-key',
   TRAM_STATE_ENGINE: 'tram-state-engine',
   TRAM_GLOBAL_STATE_ENGINE: 'tram-global-state-engine',
-  TRAM_EFFECT_STORE: 'tram-effect-store'
+  TRAM_EFFECT_STORE: 'tram-effect-store',
+  TRAM_RENDER_TRACKER: 'tram-render-tracker'
 }

--- a/src/mount/mount.test.js
+++ b/src/mount/mount.test.js
@@ -3,6 +3,7 @@ const { registerHtml } = require('../dom')
 const { setupLog } = require('../log')
 const { useEffect } = require('../hooks')
 const { setupWorkingKey } = require('../working-key')
+const { setupRenderTracker } = require('../render-tracker')
 const { mount } = require('./mount')
 
 const html = registerHtml()()
@@ -92,7 +93,7 @@ describe('mount', () => {
       })
     })
 
-    describe('without effect store or working key', () => {
+    describe('without effect store, working key, or render-tracker', () => {
       describe('without existing element', () => {
         it('should create new element', () => {
           const target = document.createElement('div')
@@ -160,14 +161,15 @@ describe('mount', () => {
       })
     })
 
-    describe('with effect store and working key', () => {
+    describe('with effect store, working key, and render-tracker', () => {
       describe('without existing element', () => {
         it('should create new element', () => {
           const target = document.createElement('div')
           const mockSpace = {}
           setupLog(mockSpace, 'mock-store')
           setupWorkingKey(mockSpace, 'mock-working-key')
-          const mountWithStore = mount(mockSpace, 'mock-store', 'mock-working-key')
+          setupRenderTracker(mockSpace, 'mock-render-tracker')
+          const mountWithStore = mount(mockSpace, 'mock-store', 'mock-working-key', 'mock-render-tracker')
           const mockComponent = () => {
             return html`<div><h1>Mock Component</h1></div>`
           }

--- a/src/render-tracker/index.js
+++ b/src/render-tracker/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./render-tracker')

--- a/src/render-tracker/render-tracker.js
+++ b/src/render-tracker/render-tracker.js
@@ -1,0 +1,27 @@
+const { assertGlobalSpaceAndEngine } = require('../asserts')
+const { setup, get } = require('../namespace')
+
+/**
+ * Render tracker is a boolean which is used to indicate whether we should
+ * continue rendering or if a final render has already completed, if we should
+ * abandon the outdated render.
+ */
+
+const setupRenderTracker = setup(() => ({ shouldRender: true }))
+
+const getRenderTracker = get
+
+const setRenderTracker = (globalSpace, renderTrackerName, shouldRender) => {
+  assertGlobalSpaceAndEngine('renderTrackerName', globalSpace, renderTrackerName)
+
+  const renderTracker = getRenderTracker(globalSpace, renderTrackerName)
+
+  // if there is no log store, return should render value
+  if (!renderTracker) return { shouldRender }
+
+  renderTracker.shouldRender = shouldRender
+
+  return renderTracker
+}
+
+module.exports = { setupRenderTracker, getRenderTracker, setRenderTracker }

--- a/src/render-tracker/render-tracker.test.js
+++ b/src/render-tracker/render-tracker.test.js
@@ -1,0 +1,41 @@
+const { setupRenderTracker, getRenderTracker, setRenderTracker } = require('./render-tracker')
+
+describe('render-tracker', () => {
+  describe('setupRenderTracker', () => {
+    it('should create new render-tracker if none exists', () => {
+      const mockSpace = {}
+      const setupResult = setupRenderTracker(mockSpace, 'mock-render-tracker')
+      expect(setupResult).toBeDefined()
+    })
+  })
+
+  describe('getRenderTracker', () => {
+    it('should return renderTracker if it has been setup', () => {
+      const mockSpace = {}
+      const renderTracker = setupRenderTracker(mockSpace, 'mock-render-tracker')
+      const getResult = getRenderTracker(mockSpace, 'mock-render-tracker')
+      expect(getResult).toBe(renderTracker)
+    })
+  })
+
+  describe('setRenderTracker', () => {
+    it('should return value passed in if there is no globalSpace', () => {
+      const setResult = setRenderTracker(null, 'mock-render-tracker', false)
+      expect(setResult).toEqual({ shouldRender: false })
+    })
+
+    it('should return value passed in if there is no renderTracker', () => {
+      const mockSpace = {}
+      const setResult = setRenderTracker(mockSpace, 'mock-render-tracker', false)
+      expect(setResult).toEqual({ shouldRender: false })
+    })
+
+    it('should set the value for renderTracker if one exists', () => {
+      const mockSpace = {}
+      const renderTracker = setupRenderTracker(mockSpace, 'mock-render-tracker')
+      const setResult = setRenderTracker(mockSpace, 'mock-render-tracker', false)
+      expect(setResult).toEqual({ shouldRender: false })
+      expect(renderTracker.shouldRender).toBe(false)
+    })
+  })
+})

--- a/src/tram-one/tram-one.test.js
+++ b/src/tram-one/tram-one.test.js
@@ -1,0 +1,124 @@
+const urlListener = require('url-listener')
+const { registerHtml, registerSvg, useState, useEffect, useGlobalState, useUrlParams, start } = require('./tram-one')
+const rootHtml = registerHtml()
+
+describe('Tram-One', () => {
+  it('should render app with custom components', () => {
+    const customHeader = () => {
+      return rootHtml`<h1>Tram-One</h1>`
+    }
+
+    const html = registerHtml({ 'custom-header': customHeader })
+    const home = () => html`
+      <div>
+        <custom-header />
+        <span>Hello World</span>
+      </div>
+    `
+
+    const mockPage = document.createElement('div')
+    start(mockPage, home)
+    expect(mockPage.outerHTML).toEqual('<div><div><h1>Tram-One</h1><span>Hello World</span></div></div>')
+  })
+
+  it('should render an app that uses SVG components', () => {
+    const svg = registerSvg()
+    const customHeader = () => svg`
+      <svg>
+        <rect width="200" height ="100" stroke="green" stroke-width="4" fill="yellow" />
+      </svg>
+    `
+
+    const html = registerHtml({ 'custom-header': customHeader })
+    const home = () => html`
+      <div>
+        <custom-header />
+        <span>Hello World</span>
+      </div>
+    `
+
+    const mockPage = document.createElement('div')
+    start(mockPage, home)
+    expect(mockPage.querySelector('rect').namespaceURI).toEqual('http://www.w3.org/2000/svg')
+  })
+
+  it('should trigger side-effects on start', () => {
+    const home = () => {
+      useEffect(() => {
+        document.title = 'Tram-One Rules!'
+      })
+      return rootHtml`
+        <div>Hello World</div>
+      `
+    }
+
+    const mockPage = document.createElement('div')
+
+    start(mockPage, home)
+    expect(document.title).toEqual('Tram-One Rules!')
+  })
+
+  it('should render app which immediately updates', () => {
+    const counter = () => {
+      const [count, setCount] = useState(5)
+      if (count < 10) {
+        setCount(15)
+      }
+
+      return rootHtml`<div>${count}</div>`
+    }
+
+    const mockPage = document.createElement('div')
+    start(mockPage, counter)
+    expect(mockPage.outerHTML).toEqual('<div><div>15</div></div>')
+  })
+
+  it('should render app which uses global state', () => {
+    const login = () => {
+      const [name, setName] = useGlobalState('name', '')
+      if (name === '') {
+        setName('Jesse')
+      }
+
+      return rootHtml`<div>Logged in as ${name}</div>`
+    }
+
+    const nameHeader = () => {
+      const [name] = useGlobalState('name')
+      return rootHtml`<div>Hello ${name}</div>`
+    }
+
+    const html = registerHtml({
+      'login': login,
+      'name-header': nameHeader
+    })
+
+    const home = () => html`
+      <div>
+        <login />
+        <name-header />
+      </div>
+    `
+    const mockPage = document.createElement('div')
+    start(mockPage, home)
+    expect(mockPage.outerHTML).toEqual('<div><div><div>Logged in as Jesse</div><div>Hello Jesse</div></div></div>')
+  })
+
+  it('should render app which uses query params', (done) => {
+    const home = () => {
+      if (useUrlParams('#A')) return rootHtml`<div>On Page A</div>`
+      if (useUrlParams('#B')) return rootHtml`<div>On Page B</div>`
+      return rootHtml`<div>Page Not Found</div>`
+    }
+
+    const mockPage = document.createElement('div')
+
+    urlListener(() => {
+      expect(mockPage.outerHTML).toEqual('<div><div>On Page B</div></div>')
+      done()
+    })
+
+    document.location.hash = 'B'
+    start(mockPage, home)
+  })
+})


### PR DESCRIPTION
## Summary

Missing commits from #114 , includes a new render-tracker which will prevent re-renders that show old dom, and psuedo integration tests.