### PR TITLE
Update effect

### DIFF
--- a/docs/badges/cjs.svg
+++ b/docs/badges/cjs.svg
@@ -14,7 +14,7 @@
   <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
     <text x="16.5" y="15" fill="#010101" fill-opacity=".3">cjs</text>
     <text x="16.5" y="14">cjs</text>
-    <text x="59" y="15" fill="#010101" fill-opacity=".3">31.64 kB</text>
-    <text x="59" y="14">31.64 kB</text>
+    <text x="59" y="15" fill="#010101" fill-opacity=".3">32.46 kB</text>
+    <text x="59" y="14">32.46 kB</text>
   </g>
 </svg>

--- a/docs/badges/cjs.svg
+++ b/docs/badges/cjs.svg
@@ -14,7 +14,7 @@
   <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
     <text x="16.5" y="15" fill="#010101" fill-opacity=".3">cjs</text>
     <text x="16.5" y="14">cjs</text>
-    <text x="59" y="15" fill="#010101" fill-opacity=".3">31.39 kB</text>
-    <text x="59" y="14">31.39 kB</text>
+    <text x="59" y="15" fill="#010101" fill-opacity=".3">31.64 kB</text>
+    <text x="59" y="14">31.64 kB</text>
   </g>
 </svg>

--- a/docs/badges/umd.svg
+++ b/docs/badges/umd.svg
@@ -14,7 +14,7 @@
   <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
     <text x="16.5" y="15" fill="#010101" fill-opacity=".3">umd</text>
     <text x="16.5" y="14">umd</text>
-    <text x="59" y="15" fill="#010101" fill-opacity=".3">46.44 kB</text>
-    <text x="59" y="14">46.44 kB</text>
+    <text x="59" y="15" fill="#010101" fill-opacity=".3">46.47 kB</text>
+    <text x="59" y="14">46.47 kB</text>
   </g>
 </svg>

--- a/docs/badges/umd.svg
+++ b/docs/badges/umd.svg
@@ -14,7 +14,7 @@
   <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
     <text x="16.5" y="15" fill="#010101" fill-opacity=".3">umd</text>
     <text x="16.5" y="14">umd</text>
-    <text x="59" y="15" fill="#010101" fill-opacity=".3">46.47 kB</text>
-    <text x="59" y="14">46.47 kB</text>
+    <text x="59" y="15" fill="#010101" fill-opacity=".3">46.68 kB</text>
+    <text x="59" y="14">46.68 kB</text>
   </g>
 </svg>

--- a/integration-tests/run-tests.js
+++ b/integration-tests/run-tests.js
@@ -3,6 +3,7 @@ const routingSpec = require('./specs/routing-spec')
 const sideEffectSpec = require('./specs/side-effect-spec')
 const svgSpec = require('./specs/svg-spec')
 const umdSpec = require('./specs/umd-spec')
+const updatedEffectSpec = require('./specs/updated-effect-spec')
 const useGlobalSpec = require('./specs/use-global-spec')
 
 const endSpec = require('./test-utilities/end-spec')
@@ -14,6 +15,7 @@ const runTests = async () => {
     const sideEffectResults = await sideEffectSpec()
     const svgResults = await svgSpec()
     const umdResults = await umdSpec()
+    const updatedEffectResults = await updatedEffectSpec()
     const useGlobalResults = await useGlobalSpec()
 
     const results = [
@@ -22,12 +24,13 @@ const runTests = async () => {
       sideEffectResults,
       svgResults,
       umdResults,
+      updatedEffectResults,
       useGlobalResults
     ].reduce((totalResults, resultList) => totalResults.concat(resultList))
 
     endSpec(results)
   } catch (error) {
-
+    throw error
   }
 }
 

--- a/integration-tests/specs/updated-effect-spec/index.html
+++ b/integration-tests/specs/updated-effect-spec/index.html
@@ -1,0 +1,29 @@
+<html>
+  <head>
+    <script src="http://localhost:1228/tram-one.umd.js"></script>
+  </head>
+  <body>
+    <div class="main"></div>
+    <script>
+      const { registerHtml, useEffect, useState, start } = window['tram-one']
+      const html = registerHtml()
+
+      const page = () => {
+        const [title, updateTitle] = useState('')
+        const onTitleChange = event => updateTitle(event.target.value)
+        useEffect(() => {
+          document.title = title
+        }, [title])
+
+        return html`
+          <div>
+            <h1>Tram-One App</h1>
+            <input id="title-input" value=${title} onkeyup=${onTitleChange} />
+          </div>
+        `
+      }
+
+      start('.main', page)
+    </script>
+  </body>
+</html>

--- a/integration-tests/specs/updated-effect-spec/index.js
+++ b/integration-tests/specs/updated-effect-spec/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./updated-effect-spec')

--- a/integration-tests/specs/updated-effect-spec/updated-effect-spec.js
+++ b/integration-tests/specs/updated-effect-spec/updated-effect-spec.js
@@ -1,0 +1,17 @@
+const serverSpec = require('../../test-utilities/setup-server')
+const isTrue = require('../../test-utilities/is-true')
+
+module.exports = () => {
+  return serverSpec('updated-effect spec', __dirname, async (nightmare, host) => {
+    const results = []
+
+    // start electron instance and tests on the page
+    await nightmare
+      .goto(host)
+      .type('#title-input', 'Tram One Rules!')
+      .evaluate(() => document.title)
+      .then(title => isTrue(title, 'title', 'Tram One Rules!', results))
+
+    return results
+  })
+}

--- a/integration-tests/test-utilities/is-true.js
+++ b/integration-tests/test-utilities/is-true.js
@@ -4,6 +4,7 @@ module.exports = (value, valueName, shouldBe, results) => {
   const passed = value === shouldBe
   const type = passed ? 'pass' : 'error'
   const prefix = passed ? '✔' : '✘'
+  const color = passed ? 'green' : 'red'
 
-  results.push({ type: type, message: chalk.green(`${prefix} ${valueName} should be ${shouldBe}`) })
+  results.push({ type: type, message: chalk[color](`${prefix} ${valueName} should be ${shouldBe}${passed ? '' : `, but was ${value}`}`) })
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tram-one",
-  "version": "8.0.4",
+  "version": "8.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tram-one",
-  "version": "8.0.5",
+  "version": "8.1.0",
   "description": "🚋 Batteries Included View Framework",
   "main": "dist/tram-one.cjs.js",
   "commonjs": "dist/tram-one.cjs.js",

--- a/src/asserts/asserts.js
+++ b/src/asserts/asserts.js
@@ -30,6 +30,23 @@ const assertIsObject = (value, variable, orUndefined = false, shape = 'an object
 }
 
 /**
+ * verify that value is an array, and throw an assert warning if it is not
+ * @param {*} value - value to check
+ * @param {string} variable - name of variable
+ * @param {boolean} [orUndefined=false] - if being undefined is allowed
+ * @param {string} [shape='an object'] - what the value should be (in words)
+ *
+ * @example
+ * triggers = []
+ * assertIsArray(triggers, 'triggers', false, 'list of values')
+ */
+const assertIsArray = (value, variable, orUndefined = false, shape = 'an array') => {
+  if (orUndefined && undefinedCheck(value)) return
+  assert.strictEqual(typeof value, 'object', `Tram-One: ${variable} should be ${shape}`)
+  assert.ok((Array.isArray(value)), `Tram-One: ${variable} should be ${shape}`)
+}
+
+/**
  * verify that value is a string, and throw an assert warning if it is not
  * @param {*} value - value to check
  * @param {string} variable - name of variable
@@ -87,4 +104,4 @@ const assertGlobalSpaceAndEngine = (engineName, globalSpace, engineValue) => {
   assertIsString(engineValue, engineName)
 }
 
-module.exports = { assertIsObject, assertIsString, assertIsFunction, assertIsDefined, assertGlobalSpaceAndEngine }
+module.exports = { assertIsObject, assertIsArray, assertIsString, assertIsFunction, assertIsDefined, assertGlobalSpaceAndEngine }

--- a/src/asserts/asserts.test.js
+++ b/src/asserts/asserts.test.js
@@ -70,6 +70,75 @@ describe('asserts', () => {
     })
   })
 
+  describe('assertIsArray', () => {
+    describe('with undefined', () => {
+      it('should not throw error if undefined is allowed', () => {
+        const check = () => asserts.assertIsArray(undefined, 'test-object', true)
+        expect(check).not.toThrow()
+      })
+
+      it('should throw error if undefined is not allowed', () => {
+        const check = () => asserts.assertIsArray(undefined, 'test-object', false)
+        expect(check).toThrow()
+      })
+
+      it('should throw error by default', () => {
+        const check = () => asserts.assertIsArray(undefined, 'test-object')
+        expect(check).toThrow()
+      })
+    })
+
+    describe('with value', () => {
+      it('should throw if value is an object', () => {
+        const check = () => asserts.assertIsArray({}, 'test-object', true)
+        expect(check).toThrow()
+      })
+
+      it('should not throw if value is an array', () => {
+        const check = () => asserts.assertIsArray([], 'test-object', true)
+        expect(check).not.toThrow()
+      })
+
+      it('should throw if value is a string', () => {
+        const check = () => asserts.assertIsArray('', 'test-object', true)
+        expect(check).toThrow()
+      })
+
+      it('should throw if value is a number', () => {
+        const check = () => asserts.assertIsArray(10, 'test-object', true)
+        expect(check).toThrow()
+      })
+
+      it('should throw if value is a function', () => {
+        const check = () => asserts.assertIsArray(() => {}, 'test-object', true)
+        expect(check).toThrow()
+      })
+    })
+
+    describe('throw message', () => {
+      it('should include variable name', () => {
+        const check = () => asserts.assertIsArray(() => {}, 'test-object', true)
+        expect(check).toThrow(expect.objectContaining({
+          message: expect.stringMatching(/test-object/)
+        }))
+      })
+
+      it('should include shape', () => {
+        const check = () => asserts.assertIsArray(() => {}, 'test-object', true, 'some kinda array')
+        expect(check).toThrow(expect.objectContaining({
+          message: expect.stringMatching(/some kinda array/)
+        }))
+      })
+
+      it('should include `an object` by default', () => {
+        const check = () => asserts.assertIsArray(() => {}, 'test-object', true)
+        expect(check).toThrow(expect.objectContaining({
+          message: expect.stringMatching(/an array/)
+        }))
+      })
+    })
+  })
+
   describe('assertIsString', () => {
     describe('with undefined', () => {
       it('should not throw error if undefined is allowed', () => {

--- a/src/hooks/useEffect.doc.js
+++ b/src/hooks/useEffect.doc.js
@@ -36,31 +36,31 @@
  * @instance
  *
  * @description
- * Hook that runs when the component first renders.
- * If the result of onEffect is another function,
- * then that function is called on when the component is removed.
+ * Hook that triggers component start, update, and cleanup effects.
+ * If the result of onEffect is another function, then that function is called on when the component is removed.
  *
- * <blockquote>
- *   <strong>Note! This is unique from react's useEffect hook in the following ways:</strong>
- *   <ul>
- *   <li>it takes no dependencies</li>
- *   <li>it is not called on update</li>
- *   <li>if {@link onEffect} does not return a function, the return is ignored (async effects are okay)</li>
- *   </ul>
- * </blockquote>
+ * If there are triggers passed in, when those values are updated, the cleanup will also get called, and
+ * the onEffect will trigger again. It is a common pattern to list any value used in the effect as a trigger.
+ *
+ * If {@link onEffect} does not return a function, the return is ignored, which means async
+ * functions are okay!
  *
  * @param {onEffect} onEffect function to run on component mount
+ * @param {Array} [triggers] list of values that when updated will trigger the effect again
  *
  * @example
- * import { registerHtml, useEffect } from 'tram-one'
+ * import { registerHtml, useEffect, useState } from 'tram-one'
  * const html = registerHtml()
  *
  *
  * export default () => {
- *   useEffect(() => {
- *     document.title = "Page Title"
- *   })
+ *   const [title, updateTitle] = useState('Tram-One App')
+ *   onUpdateTitle = (event) => updateTitle(event.target.value)
  *
- *   return html`<h1>Page Title</h1>`
+ *   useEffect(() => {
+ *     document.title = title
+ *   }, [title])
+ *
+ *   return html`<input value=${title} onkeydown=${onUpdateTitle} />`
  * }
  */

--- a/src/hooks/useEffect.js
+++ b/src/hooks/useEffect.js
@@ -1,7 +1,7 @@
 const { TRAM_HOOK_KEY, TRAM_EFFECT_QUEUE } = require('../engine-names')
 const { getEffectStore } = require('../effect-store')
 const { getWorkingKeyValue, incrementWorkingKeyBranch } = require('../working-key')
-const { assertGlobalSpaceAndEngine, assertIsFunction } = require('../asserts')
+const { assertGlobalSpaceAndEngine, assertIsFunction, assertIsArray } = require('../asserts')
 
 /**
  * This file defines one function, useEffect, which is a hook that
@@ -19,6 +19,7 @@ module.exports = (globalSpace, storeName = TRAM_EFFECT_QUEUE, workingKeyName = T
 
   return (onEffect, triggers = []) => {
     assertIsFunction(onEffect, 'effect')
+    assertIsArray(triggers, 'triggers', true)
 
     // get the store of effects
     const effectStore = getEffectStore(globalSpace, storeName)

--- a/src/hooks/useEffect.test.js
+++ b/src/hooks/useEffect.test.js
@@ -29,7 +29,7 @@ describe('useEffect', () => {
     })
   })
 
-  describe('with no effect store', () => {
+  describe('with no effect store or key', () => {
     it('should immediately run the start effect', () => {
       const mockSpace = {}
       const useEffectNoStore = useEffect(mockSpace, 'mock-effect-store', 'mock-working-key')
@@ -52,36 +52,6 @@ describe('useEffect', () => {
       }
 
       useEffectNoStore(mockEffect)
-
-      expect(endEffect).toHaveBeenCalled()
-    })
-  })
-
-  describe('without working key', () => {
-    it('should immediately run the start effect', () => {
-      const mockSpace = {}
-      setupEffectStore(mockSpace, 'mock-effect-store')
-      const useEffectNoKey = useEffect(mockSpace, 'mock-effect-store', 'mock-working-key')
-      const startEffect = jest.fn()
-      const mockEffect = () => {
-        startEffect()
-      }
-
-      useEffectNoKey(mockEffect)
-
-      expect(startEffect).toHaveBeenCalled()
-    })
-
-    it('should immediately run the cleanup effect', () => {
-      const mockSpace = {}
-      setupEffectStore(mockSpace, 'mock-effect-store')
-      const useEffectNoKey = useEffect(mockSpace, 'mock-effect-store', 'mock-working-key')
-      const endEffect = jest.fn()
-      const mockEffect = () => {
-        return endEffect
-      }
-
-      useEffectNoKey(mockEffect)
 
       expect(endEffect).toHaveBeenCalled()
     })
@@ -115,7 +85,24 @@ describe('useEffect', () => {
 
       useEffectWithStoreAndKey(mockEffect)
 
-      expect(mockSpace['mock-effect-store']['[0]']).toBe(mockEffect)
+      expect(Object.keys(mockSpace['mock-effect-store'])).toContain('[0]()')
+      expect(mockSpace['mock-effect-store']['[0]()']).toBe(mockEffect)
+    })
+
+    it('should store the effect with triggers', () => {
+      const mockSpace = {}
+      setupEffectStore(mockSpace, 'mock-effect-store')
+      setupWorkingKey(mockSpace, 'mock-working-key')
+      const useEffectWithStoreAndKey = useEffect(mockSpace, 'mock-effect-store', 'mock-working-key')
+      const startEffect = jest.fn()
+      const mockEffect = () => {
+        startEffect()
+      }
+
+      useEffectWithStoreAndKey(mockEffect, ['mock-trigger', 'mock-second-trigger'])
+
+      expect(Object.keys(mockSpace['mock-effect-store'])).toContain('[0](mock-trigger:mock-second-trigger)')
+      expect(mockSpace['mock-effect-store']['[0](mock-trigger:mock-second-trigger)']).toBe(mockEffect)
     })
   })
 })

--- a/src/mount/mount.test.js
+++ b/src/mount/mount.test.js
@@ -236,6 +236,78 @@ describe('mount', () => {
           expect(mockStartEffect).not.toHaveBeenCalled()
           expect(mockCleanupEffect).toHaveBeenCalled()
         })
+
+        it('should call effects on second mount with updated triggers', () => {
+          const target = document.createElement('div')
+          const mockSpace = {}
+          setupEffectStore(mockSpace, 'mock-store')
+          setupEffectStore(mockSpace, 'mock-queue')
+          setupWorkingKey(mockSpace, 'mock-working-key')
+          setupRenderLock(mockSpace, 'mock-render-lock')
+          const mountWithStore = mount(mockSpace, 'mock-store', 'mock-queue', 'mock-working-key', 'mock-render-lock')
+          const mockStartEffect = jest.fn()
+          const mockCleanupEffect = jest.fn()
+          const mockEffect = () => {
+            mockStartEffect()
+            return mockCleanupEffect
+          }
+
+          const mockComponent = () => {
+            useEffect(mockSpace, 'mock-queue', 'mock-working-key')(mockEffect, [0])
+            return html`<div><h1>Mock Component</h1></div>`
+          }
+
+          mountWithStore(target, mockComponent)
+          const mockComponentUpdate = () => {
+            useEffect(mockSpace, 'mock-queue', 'mock-working-key')(mockEffect, [1])
+            return html`<div><h1>Mock Component</h1></div>`
+          }
+
+          mountWithStore(target, mockComponent)
+          expect(mockStartEffect).toHaveBeenCalled()
+          expect(mockCleanupEffect).not.toHaveBeenCalled()
+          mockStartEffect.mockClear()
+          mockCleanupEffect.mockClear()
+          mountWithStore(target, mockComponentUpdate)
+          expect(mockCleanupEffect).toHaveBeenCalled()
+          expect(mockStartEffect).toHaveBeenCalled()
+        })
+
+        it('should not call effects on second mount with same triggers', () => {
+          const target = document.createElement('div')
+          const mockSpace = {}
+          setupEffectStore(mockSpace, 'mock-store')
+          setupEffectStore(mockSpace, 'mock-queue')
+          setupWorkingKey(mockSpace, 'mock-working-key')
+          setupRenderLock(mockSpace, 'mock-render-lock')
+          const mountWithStore = mount(mockSpace, 'mock-store', 'mock-queue', 'mock-working-key', 'mock-render-lock')
+          const mockStartEffect = jest.fn()
+          const mockCleanupEffect = jest.fn()
+          const mockEffect = () => {
+            mockStartEffect()
+            return mockCleanupEffect
+          }
+
+          const mockComponent = () => {
+            useEffect(mockSpace, 'mock-queue', 'mock-working-key')(mockEffect, [0])
+            return html`<div><h1>Mock Component</h1></div>`
+          }
+
+          mountWithStore(target, mockComponent)
+          const mockComponentUpdate = () => {
+            useEffect(mockSpace, 'mock-queue', 'mock-working-key')(mockEffect, [0])
+            return html`<div><h1>Mock Component</h1></div>`
+          }
+
+          mountWithStore(target, mockComponent)
+          expect(mockStartEffect).toHaveBeenCalled()
+          expect(mockCleanupEffect).not.toHaveBeenCalled()
+          mockStartEffect.mockClear()
+          mockCleanupEffect.mockClear()
+          mountWithStore(target, mockComponentUpdate)
+          expect(mockCleanupEffect).not.toHaveBeenCalled()
+          expect(mockStartEffect).not.toHaveBeenCalled()
+        })
       })
     })
   })


### PR DESCRIPTION
## Summary

To better match React's hook's functionality, useEffect now takes in a list of `triggers` which will cause an effect to cleanup and re-trigger if it has been updated.

Luckily, this was a fairly easy and simple change. Included in the PR are integration and unit tests.