### PR TITLE
fix effect store bug, bump patch v8.1.1

### DIFF
--- a/docs/badges/umd.svg
+++ b/docs/badges/umd.svg
@@ -14,7 +14,7 @@
   <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
     <text x="16.5" y="15" fill="#010101" fill-opacity=".3">umd</text>
     <text x="16.5" y="14">umd</text>
-    <text x="59" y="15" fill="#010101" fill-opacity=".3">46.68 kB</text>
-    <text x="59" y="14">46.68 kB</text>
+    <text x="59" y="15" fill="#010101" fill-opacity=".3">46.67 kB</text>
+    <text x="59" y="14">46.67 kB</text>
   </g>
 </svg>

--- a/integration-tests/specs/updated-effect-spec/updated-effect-spec.js
+++ b/integration-tests/specs/updated-effect-spec/updated-effect-spec.js
@@ -12,6 +12,16 @@ module.exports = () => {
       .evaluate(() => document.title)
       .then(title => isTrue(title, 'title', 'Tram One Rules!', results))
 
+    await nightmare
+      .goto(host)
+      .type('#title-input', 'Tram One Rules!')
+      .type('#title-input')
+      .type('#title-input', 'Tram One is Cool')
+      .type('#title-input')
+      .type('#title-input', 'Tram One Rules!')
+      .evaluate(() => document.title)
+      .then(title => isTrue(title, 'title', 'Tram One Rules!', results))
+
     return results
   })
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tram-one",
-  "version": "8.1.0",
+  "version": "8.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tram-one",
-  "version": "8.1.0",
+  "version": "8.1.1",
   "description": "🚋 Batteries Included View Framework",
   "main": "dist/tram-one.cjs.js",
   "commonjs": "dist/tram-one.cjs.js",

--- a/src/mount/mount.js
+++ b/src/mount/mount.js
@@ -101,6 +101,7 @@ const mount = (globalSpace, effectStore = TRAM_EFFECT_STORE, effectQueue = TRAM_
             // call clean up effect
             existingEffects[effectKey]()
           }
+
           // remove effect from effectStore
           delete getEffectStore(globalSpace, effectStore)[effectKey]
         })

--- a/src/mount/mount.js
+++ b/src/mount/mount.js
@@ -96,10 +96,11 @@ const mount = (globalSpace, effectStore = TRAM_EFFECT_STORE, effectQueue = TRAM_
 
       // run all clean up effects if the effect was removed and is a function
       removedEffectKeys
-        .filter(effectKey => typeof existingEffects[effectKey] === 'function')
         .forEach(effectKey => {
-          // call clean up effect
-          existingEffects[effectKey]()
+          if (typeof existingEffects[effectKey] === 'function') {
+            // call clean up effect
+            existingEffects[effectKey]()
+          }
           // remove effect from effectStore
           delete getEffectStore(globalSpace, effectStore)[effectKey]
         })


### PR DESCRIPTION
## Summary

Effect store was not clearing if there was no cleanup, this change ensures that even if there is no cleanup that we remove the effect from the store. 

* added new integration tests