### PR TITLE
update sandbox link to reflect tram-one-express template

### DIFF
--- a/configs/docma.json
+++ b/configs/docma.json
@@ -67,7 +67,7 @@
             "items": [
               {
                 "label": "CodeSandbox",
-                "href": "https://codesandbox.io/s/tramone-sample-app-lvt6u",
+                "href": "https://codesandbox.io/s/github/Tram-One/tram-one-express/tree/tram-one-example",
                 "target": "_blank"
               },
               {


### PR DESCRIPTION
## Summary

This PR updates the sandbox link to use the linked template that we now generate (https://github.com/Tram-One/tram-one-express/pull/88). You can see this link now on the website under the *Try Now* dropdown.