### PR TITLE
remove hacktoberfest link

### DIFF
--- a/configs/docma.json
+++ b/configs/docma.json
@@ -85,10 +85,6 @@
             ]
           },
           {
-            "label": "Hacktoberfest",
-            "href": "/hacktoberfest"
-          },
-          {
             "iconClass": "fab fa-lg fa-slack",
             "label": "",
             "href": "https://join.slack.com/t/tram-one/shared_invite/enQtMjY0NDA3OTg2MzQyLWUyMGIyZTYwNzZkNDJiNWNmNzdiOTMzYjg0YzMzZTkzZDE4MTlmN2Q2YjE0NDIwMGI3ODEzYzQ4ODdlMzQ2ODM",


### PR DESCRIPTION
## Summary

This PR removes removes the link at the top of the page for hacktoberfest. The page still exists, so that we don't 404, and can re-use it for Hacktoberfest next year.

![image](https://user-images.githubusercontent.com/326557/68090038-41afa100-fe3d-11e9-8aee-7d5fff4858d5.png)
