### PR TITLE
update website to use codesandbox samples

### DIFF
--- a/configs/docma.json
+++ b/configs/docma.json
@@ -71,8 +71,8 @@
             "label": "Try It",
             "items": [
               {
-                "label": "StackBlitz",
-                "href": "https://stackblitz.com/edit/tram-one-blank-template?file=index.js",
+                "label": "CodeSandbox",
+                "href": "https://codesandbox.io/s/github/Tram-One/tram-one-express/tree/tram-one-example",
                 "target": "_blank"
               },
               {

--- a/docs/badges/cjs.svg
+++ b/docs/badges/cjs.svg
@@ -14,7 +14,7 @@
   <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
     <text x="16.5" y="15" fill="#010101" fill-opacity=".3">cjs</text>
     <text x="16.5" y="14">cjs</text>
-    <text x="59" y="15" fill="#010101" fill-opacity=".3">33.83 kB</text>
-    <text x="59" y="14">33.83 kB</text>
+    <text x="59" y="15" fill="#010101" fill-opacity=".3">31.48 kB</text>
+    <text x="59" y="14">31.48 kB</text>
   </g>
 </svg>

--- a/docs/badges/cjs.svg
+++ b/docs/badges/cjs.svg
@@ -14,7 +14,7 @@
   <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
     <text x="16.5" y="15" fill="#010101" fill-opacity=".3">cjs</text>
     <text x="16.5" y="14">cjs</text>
-    <text x="59" y="15" fill="#010101" fill-opacity=".3">30.39 kB</text>
-    <text x="59" y="14">30.39 kB</text>
+    <text x="59" y="15" fill="#010101" fill-opacity=".3">33.83 kB</text>
+    <text x="59" y="14">33.83 kB</text>
   </g>
 </svg>

--- a/docs/guides/introduction.md
+++ b/docs/guides/introduction.md
@@ -34,25 +34,28 @@ Tram-One is a light View Framework that comes with all the dependencies you need
 Tram-One is an orchestration of common features, and relies only on plain pure javascript, so you don't have to bother learning / parsing / transpiling special templating languages. It relies only on ES6 Template Strings, which are [supported in most major browsers](https://caniuse.com/#feat=template-literals).
 
 <iframe
-	src="https://stackblitz.com/edit/tram-one-docs-introduction-example-one?embed=1&file=index.js&hideExplorer=1"
-	width="100%"
-	height="350px"
+	src="https://codesandbox.io/embed/github/Tram-One/tram-one-samples/tree/introduction-example-one/?autoresize=1&fontsize=14&hidenavigation=1&module=%2Findex.js&theme=dark"
+	style="width:100%; height:350px; border:0; border-radius: 4px; overflow:hidden;"
+	allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media; usb"
+	sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
 ></iframe>
 
 Tram-One takes inspiration from frameworks like [Choo](https://choo.io/), [React](https://reactjs.org/), and [Svelte](https://svelte.dev/). Tram-One includes a set of default hooks, similar to React and Svelte, which allow for
 routing, effects, component state, and global state management.
 
 <iframe
-	src="https://stackblitz.com/edit/tram-one-docs-introduction-example-two?embed=1&file=index.js&hideExplorer=1"
-	width="100%"
-	height="350px"
+	src="https://codesandbox.io/embed/github/Tram-One/tram-one-samples/tree/introduction-example-two/?autoresize=1&fontsize=14&hidenavigation=1&module=%2Findex.js&theme=dark"
+	style="width:100%; height:350px; border:0; border-radius: 4px; overflow:hidden;"
+	allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media; usb"
+	sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
 ></iframe>
 
 The syntax is based on similar modules that Choo uses, offering custom components in a
 js template syntax that should be familiar and confortable to React developers.
 
 <iframe
-	src="https://stackblitz.com/edit/tram-one-docs-introduction-example-three?embed=1&file=index.js&hideExplorer=1"
-	width="100%"
-	height="350px"
+	src="https://codesandbox.io/embed/github/Tram-One/tram-one-samples/tree/introduction-example-three/?autoresize=1&fontsize=14&hidenavigation=1&module=%2Findex.js&theme=dark"
+	style="width:100%; height:350px; border:0; border-radius: 4px; overflow:hidden;"
+	allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media; usb"
+	sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
 ></iframe>

--- a/docs/guides/introduction.md
+++ b/docs/guides/introduction.md
@@ -36,8 +36,6 @@ Tram-One is an orchestration of common features, and relies only on plain pure j
 <iframe
 	src="https://codesandbox.io/embed/github/Tram-One/tram-one-samples/tree/introduction-example-one/?autoresize=1&fontsize=14&hidenavigation=1&module=%2Findex.js&theme=dark"
 	style="width:100%; height:350px; border:0; border-radius: 4px; overflow:hidden;"
-	allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media; usb"
-	sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
 ></iframe>
 
 Tram-One takes inspiration from frameworks like [Choo](https://choo.io/), [React](https://reactjs.org/), and [Svelte](https://svelte.dev/). Tram-One includes a set of default hooks, similar to React and Svelte, which allow for
@@ -46,8 +44,6 @@ routing, effects, component state, and global state management.
 <iframe
 	src="https://codesandbox.io/embed/github/Tram-One/tram-one-samples/tree/introduction-example-two/?autoresize=1&fontsize=14&hidenavigation=1&module=%2Findex.js&theme=dark"
 	style="width:100%; height:350px; border:0; border-radius: 4px; overflow:hidden;"
-	allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media; usb"
-	sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
 ></iframe>
 
 The syntax is based on similar modules that Choo uses, offering custom components in a
@@ -56,6 +52,4 @@ js template syntax that should be familiar and confortable to React developers.
 <iframe
 	src="https://codesandbox.io/embed/github/Tram-One/tram-one-samples/tree/introduction-example-three/?autoresize=1&fontsize=14&hidenavigation=1&module=%2Findex.js&theme=dark"
 	style="width:100%; height:350px; border:0; border-radius: 4px; overflow:hidden;"
-	allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media; usb"
-	sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
 ></iframe>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tram-one",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tram-one",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "description": "🚋 Batteries Included View Framework",
   "main": "dist/tram-one.cjs.js",
   "commonjs": "dist/tram-one.cjs.js",

--- a/src/dom-wrappers.js
+++ b/src/dom-wrappers.js
@@ -8,18 +8,20 @@ const { registerDom } = require('./dom')
  * Function to generate a tagged template function for XHTML / HTML.
  * Takes in a registry that allows you to import other tag functions and use them in your template string.
  *
- * StackBlitz for registerHtml with no registry
+ * Sandbox for registerHtml with no registery
  * <iframe
- *	 src="https://stackblitz.com/edit/tram-one-docs-registerhtml-example-one?embed=1&file=index.js&hideExplorer=1"
- *	 width="100%"
- *	 height="300px"
+ *	 src="https://codesandbox.io/embed/github/Tram-One/tram-one-samples/tree/registerhtml-example-one/?autoresize=1&fontsize=14&hidenavigation=1&module=%2Findex.js&theme=dark"
+ *	 style="width:100%; height:350px; border:0; border-radius: 4px; overflow:hidden;"
+ *	 allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media; usb"
+ *	 sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
  * ></iframe>
  *
- * StackBlitz for registerHtml with registry (use Ctrl+P to look at `custom-header.js`)
+ * Sandbox for registerHtml with registery
  * <iframe
- *	 src="https://stackblitz.com/edit/tram-one-docs-registerhtml-example-two?embed=1&file=index.js&hideExplorer=1"
- *	 width="100%"
- *	 height="300px"
+ *	 src="https://codesandbox.io/embed/github/Tram-One/tram-one-samples/tree/registerhtml-example-two/?autoresize=1&fontsize=14&hidenavigation=1&module=%2Findex.js&theme=dark"
+ *	 style="width:100%; height:350px; border:0; border-radius: 4px; overflow:hidden;"
+ *	 allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media; usb"
+ *	 sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
  * ></iframe>
  * @param {object} [registry={}] map of tag names to functions, use this to use custom elements built in tram-one
  *
@@ -37,11 +39,11 @@ const registerHtml = registry => {
  * @description
  * Function to generate a tagged template function for SVG.
  *
- * StackBlitz for registerSvg
  * <iframe
- *	 src="https://stackblitz.com/edit/tram-one-docs-registersvg-example-one?embed=1&file=index.js&hideExplorer=1"
- *	 width="100%"
- *	 height="300px"
+ *	 src="https://codesandbox.io/embed/github/Tram-One/tram-one-samples/tree/registersvg-example-one/?autoresize=1&fontsize=14&hidenavigation=1&module=%2Findex.js&theme=dark"
+ *	 style="width:100%; height:350px; border:0; border-radius: 4px; overflow:hidden;"
+ *	 allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media; usb"
+ *	 sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
  * ></iframe>
  *
  * @param {object} [registry={}] map of tag names to functions, use this to use custom elements built in tram-one

--- a/src/dom-wrappers.js
+++ b/src/dom-wrappers.js
@@ -12,16 +12,12 @@ const { registerDom } = require('./dom')
  * <iframe
  *	 src="https://codesandbox.io/embed/github/Tram-One/tram-one-samples/tree/registerhtml-example-one/?autoresize=1&fontsize=14&hidenavigation=1&module=%2Findex.js&theme=dark"
  *	 style="width:100%; height:350px; border:0; border-radius: 4px; overflow:hidden;"
- *	 allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media; usb"
- *	 sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
  * ></iframe>
  *
  * Sandbox for registerHtml with registery
  * <iframe
  *	 src="https://codesandbox.io/embed/github/Tram-One/tram-one-samples/tree/registerhtml-example-two/?autoresize=1&fontsize=14&hidenavigation=1&module=%2Findex.js&theme=dark"
  *	 style="width:100%; height:350px; border:0; border-radius: 4px; overflow:hidden;"
- *	 allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media; usb"
- *	 sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
  * ></iframe>
  * @param {object} [registry={}] map of tag names to functions, use this to use custom elements built in tram-one
  *
@@ -42,8 +38,6 @@ const registerHtml = registry => {
  * <iframe
  *	 src="https://codesandbox.io/embed/github/Tram-One/tram-one-samples/tree/registersvg-example-one/?autoresize=1&fontsize=14&hidenavigation=1&module=%2Findex.js&theme=dark"
  *	 style="width:100%; height:350px; border:0; border-radius: 4px; overflow:hidden;"
- *	 allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media; usb"
- *	 sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
  * ></iframe>
  *
  * @param {object} [registry={}] map of tag names to functions, use this to use custom elements built in tram-one

--- a/src/start.js
+++ b/src/start.js
@@ -19,16 +19,12 @@ const { setupMutationObserver } = require('./mutation-observer')
  * <iframe
  *	 src="https://codesandbox.io/embed/github/Tram-One/tram-one-samples/tree/start-example-one/?autoresize=1&fontsize=14&hidenavigation=1&module=%2Findex.js&theme=dark"
  *	 style="width:100%; height:350px; border:0; border-radius: 4px; overflow:hidden;"
- *	 allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media; usb"
- *	 sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
- * ></iframe>
+s * ></iframe>
  *
  * Sandbox for starting on a dom element (useful for testing)
  * <iframe
  *	 src="https://codesandbox.io/embed/github/Tram-One/tram-one-samples/tree/start-example-two/?autoresize=1&fontsize=14&hidenavigation=1&expanddevtools=1&module=%2Findex.js&theme=dark"
  *	 style="width:100%; height:350px; border:0; border-radius: 4px; overflow:hidden;"
- *	 allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media; usb"
- *	 sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
  * ></iframe>
  *
  * @param {string|Node} selector either a CSS selector, or Node to attach the component to

--- a/src/start.js
+++ b/src/start.js
@@ -15,23 +15,25 @@ const { setupMutationObserver } = require('./mutation-observer')
  *
  * This should only be called for the initial render / building of the app.
  *
- * StackBlitz for starting with a selector on the page
+ * Sandbox for starting with a selector on the page
  * <iframe
- *	 src="https://stackblitz.com/edit/tram-one-docs-start-example-one?embed=1&file=index.js&hideExplorer=1"
- *	 width="100%"
- *	 height="300px"
+ *	 src="https://codesandbox.io/embed/github/Tram-One/tram-one-samples/tree/start-example-one/?autoresize=1&fontsize=14&hidenavigation=1&module=%2Findex.js&theme=dark"
+ *	 style="width:100%; height:350px; border:0; border-radius: 4px; overflow:hidden;"
+ *	 allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media; usb"
+ *	 sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
  * ></iframe>
  *
- * StackBlitz for starting on a dom element (useful for testing)
+ * Sandbox for starting on a dom element (useful for testing)
  * <iframe
- *	 src="https://stackblitz.com/edit/tram-one-docs-start-example-two?embed=1&file=index.js&hideExplorer=1"
- *	 width="100%"
- *	 height="300px"
+ *	 src="https://codesandbox.io/embed/github/Tram-One/tram-one-samples/tree/start-example-two/?autoresize=1&fontsize=14&hidenavigation=1&expanddevtools=1&module=%2Findex.js&theme=dark"
+ *	 style="width:100%; height:350px; border:0; border-radius: 4px; overflow:hidden;"
+ *	 allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media; usb"
+ *	 sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
  * ></iframe>
  *
  * @param {string|Node} selector either a CSS selector, or Node to attach the component to
  *
- * @param {component} component top-level component to attach to the page.
+ * @param {function} component top-level component to attach to the page.
  */
 module.exports = (selector, component) => {
 	/* setup all the internal engines required for tram-one to work */

--- a/src/use-effect.js
+++ b/src/use-effect.js
@@ -16,11 +16,12 @@ const { getWorkingKeyValue, incrementWorkingKeyBranch } = require('./working-key
  *
  * If `effect` does not return a function, the return is ignored, which means async functions are okay!
  *
- * StackBlitz for simple useEffect
+ * Sandbox for simple useEffect
  * <iframe
- *	 src="https://stackblitz.com/edit/tram-one-docs-use-effect-example-one?embed=1&file=index.js&hideExplorer=1"
- *	 width="100%"
- *	 height="300px"
+ *	 src="https://codesandbox.io/embed/github/Tram-One/tram-one-samples/tree/use-effect-example-one/?autoresize=1&fontsize=14&hidenavigation=1&module=%2Findex.js&theme=dark"
+ *	 style="width:100%; height:350px; border:0; border-radius: 4px; overflow:hidden;"
+ *	 allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media; usb"
+ *	 sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
  * ></iframe>
  * @param {function} effect function to run on component mount
  */

--- a/src/use-effect.js
+++ b/src/use-effect.js
@@ -20,8 +20,6 @@ const { getWorkingKeyValue, incrementWorkingKeyBranch } = require('./working-key
  * <iframe
  *	 src="https://codesandbox.io/embed/github/Tram-One/tram-one-samples/tree/use-effect-example-one/?autoresize=1&fontsize=14&hidenavigation=1&module=%2Findex.js&theme=dark"
  *	 style="width:100%; height:350px; border:0; border-radius: 4px; overflow:hidden;"
- *	 allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media; usb"
- *	 sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
  * ></iframe>
  * @param {function} effect function to run on component mount
  */

--- a/src/use-global-observable.js
+++ b/src/use-global-observable.js
@@ -15,8 +15,6 @@ const observableHook = require('./observable-hook')
  * <iframe
  *	 src="https://codesandbox.io/embed/github/Tram-One/tram-one-samples/tree/use-global-observable-example-one/?autoresize=1&fontsize=14&hidenavigation=1&module=%2Findex.js&theme=dark"
  *	 style="width:100%; height:350px; border:0; border-radius: 4px; overflow:hidden;"
- *	 allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media; usb"
- *	 sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
  * ></iframe>
  *
  * @param {string} key a unique string to write and read the global value

--- a/src/use-global-observable.js
+++ b/src/use-global-observable.js
@@ -11,11 +11,12 @@ const observableHook = require('./observable-hook')
  * If the value (or a subfield if it is an object or array) is updated,
  * it will cause only the components that are dependent on that value to update.
  *
- * StackBlitz for useGlobalObservable
+ * Sandbox for useGlobalObservable
  * <iframe
- *	 src="https://stackblitz.com/edit/tram-one-docs-use-global-observable-example-one?embed=1&file=index.js&hideExplorer=1"
- *	 width="100%"
- *	 height="300px"
+ *	 src="https://codesandbox.io/embed/github/Tram-One/tram-one-samples/tree/use-global-observable-example-one/?autoresize=1&fontsize=14&hidenavigation=1&module=%2Findex.js&theme=dark"
+ *	 style="width:100%; height:350px; border:0; border-radius: 4px; overflow:hidden;"
+ *	 allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media; usb"
+ *	 sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
  * ></iframe>
  *
  * @param {string} key a unique string to write and read the global value

--- a/src/use-observable.js
+++ b/src/use-observable.js
@@ -11,23 +11,25 @@ const observableHook = require('./observable-hook')
  * If the value (or a subfield if it is an object or array) is updated,
  * it will cause only the components that are dependent on that value to update.
  *
- * StackBlitz for useObservable with a primitive
+ * Sandbox for useObservable with a primitive
  * <iframe
- *	 src="https://stackblitz.com/edit/tram-one-docs-use-observable-example-one?embed=1&file=index.js&hideExplorer=1"
- *	 width="100%"
- *	 height="300px"
+ *	 src="https://codesandbox.io/embed/github/Tram-One/tram-one-samples/tree/use-observable-example-one/?autoresize=1&fontsize=14&hidenavigation=1&module=%2Findex.js&theme=dark"
+ *	 style="width:100%; height:350px; border:0; border-radius: 4px; overflow:hidden;"
+ *	 allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media; usb"
+ *	 sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
  * ></iframe>
  *
- * StackBlitz for useObservable with an object
+ * Sandbox for useObservable with an object
  * <blockquote>
  *   if storing an object or array, you should mutate the subfields directly,
  *   and avoid using the setter that is returned. This will be more performant,
  *   and cause only components that are reactive to the sub-fields to update.
  * </blockquote>
  * <iframe
- *	 src="https://stackblitz.com/edit/tram-one-docs-use-observable-example-two?embed=1&file=index.js&hideExplorer=1"
- *	 width="100%"
- *	 height="300px"
+ *	 src="https://codesandbox.io/embed/github/Tram-One/tram-one-samples/tree/use-observable-example-two/?autoresize=1&fontsize=14&hidenavigation=1&module=%2Findex.js&theme=dark"
+ *	 style="width:100%; height:350px; border:0; border-radius: 4px; overflow:hidden;"
+ *	 allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media; usb"
+ *	 sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
  * ></iframe>
  * @param {any} value the default value to start the state at
  *

--- a/src/use-observable.js
+++ b/src/use-observable.js
@@ -15,8 +15,6 @@ const observableHook = require('./observable-hook')
  * <iframe
  *	 src="https://codesandbox.io/embed/github/Tram-One/tram-one-samples/tree/use-observable-example-one/?autoresize=1&fontsize=14&hidenavigation=1&module=%2Findex.js&theme=dark"
  *	 style="width:100%; height:350px; border:0; border-radius: 4px; overflow:hidden;"
- *	 allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media; usb"
- *	 sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
  * ></iframe>
  *
  * Sandbox for useObservable with an object
@@ -28,8 +26,6 @@ const observableHook = require('./observable-hook')
  * <iframe
  *	 src="https://codesandbox.io/embed/github/Tram-One/tram-one-samples/tree/use-observable-example-two/?autoresize=1&fontsize=14&hidenavigation=1&module=%2Findex.js&theme=dark"
  *	 style="width:100%; height:350px; border:0; border-radius: 4px; overflow:hidden;"
- *	 allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media; usb"
- *	 sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
  * ></iframe>
  * @param {any} value the default value to start the state at
  *

--- a/src/use-url-params.js
+++ b/src/use-url-params.js
@@ -16,16 +16,12 @@ const useObservable = require('./use-observable')
  * <iframe
  *	 src="https://codesandbox.io/embed/github/Tram-One/tram-one-samples/tree/use-url-params-example-one/?autoresize=1&fontsize=14&hidenavigation=1&module=%2Findex.js&theme=dark"
  *	 style="width:100%; height:350px; border:0; border-radius: 4px; overflow:hidden;"
- *	 allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media; usb"
- *	 sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
  * ></iframe>
  *
  * Sandbox for reading params
  * <iframe
  *	 src="https://codesandbox.io/embed/github/Tram-One/tram-one-samples/tree/use-url-params-example-two/?autoresize=1&fontsize=14&hidenavigation=1&module=%2Findex.js&theme=dark"
  *	 style="width:100%; height:350px; border:0; border-radius: 4px; overflow:hidden;"
- *	 allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media; usb"
- *	 sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
  * ></iframe>
  *
  * @param {String} [pattern] path to match on (can include path variables)

--- a/src/use-url-params.js
+++ b/src/use-url-params.js
@@ -12,18 +12,20 @@ const useObservable = require('./use-observable')
  * It's internal functionality is powered by the package
  * {@link https://www.npmjs.com/package/rlite-router | rlite}
  *
- * StackBlitz for path checking in useUrlParams
+ * Sandbox for path checking in useUrlParams
  * <iframe
- *	 src="https://stackblitz.com/edit/tram-one-docs-use-url-params-example-one?embed=1&file=index.js&hideExplorer=1"
- *	 width="100%"
- *	 height="300px"
+ *	 src="https://codesandbox.io/embed/github/Tram-One/tram-one-samples/tree/use-url-params-example-one/?autoresize=1&fontsize=14&hidenavigation=1&module=%2Findex.js&theme=dark"
+ *	 style="width:100%; height:350px; border:0; border-radius: 4px; overflow:hidden;"
+ *	 allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media; usb"
+ *	 sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
  * ></iframe>
  *
- * StackBlitz for reading params
+ * Sandbox for reading params
  * <iframe
- *	 src="https://stackblitz.com/edit/tram-one-docs-use-url-params-example-two?embed=1&file=index.js&hideExplorer=1"
- *	 width="100%"
- *	 height="300px"
+ *	 src="https://codesandbox.io/embed/github/Tram-One/tram-one-samples/tree/use-url-params-example-two/?autoresize=1&fontsize=14&hidenavigation=1&module=%2Findex.js&theme=dark"
+ *	 style="width:100%; height:350px; border:0; border-radius: 4px; overflow:hidden;"
+ *	 allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media; usb"
+ *	 sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
  * ></iframe>
  *
  * @param {String} [pattern] path to match on (can include path variables)


### PR DESCRIPTION
## Summary

Realized that Stackblitz (which we were trying out in the previous PR), hasn't been updated in a long while, and offers less options when compared to CodeSandbox. So we've created a new repository for the samples (https://github.com/Tram-One/tram-one-samples), and we link directly to those on the website.