### PR TITLE
Fix Array in useStore (v10.0.1)

### DIFF
--- a/docs/badges/cjs.svg
+++ b/docs/badges/cjs.svg
@@ -14,7 +14,7 @@
   <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
     <text x="16.5" y="15" fill="#010101" fill-opacity=".3">cjs</text>
     <text x="16.5" y="14">cjs</text>
-    <text x="59" y="15" fill="#010101" fill-opacity=".3">25.69 kB</text>
-    <text x="59" y="14">25.69 kB</text>
+    <text x="59" y="15" fill="#010101" fill-opacity=".3">25.80 kB</text>
+    <text x="59" y="14">25.80 kB</text>
   </g>
 </svg>

--- a/docs/badges/umd.svg
+++ b/docs/badges/umd.svg
@@ -14,7 +14,7 @@
   <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
     <text x="16.5" y="15" fill="#010101" fill-opacity=".3">umd</text>
     <text x="16.5" y="14">umd</text>
-    <text x="59" y="15" fill="#010101" fill-opacity=".3">20.48 kB</text>
-    <text x="59" y="14">20.48 kB</text>
+    <text x="59" y="15" fill="#010101" fill-opacity=".3">20.50 kB</text>
+    <text x="59" y="14">20.50 kB</text>
   </g>
 </svg>

--- a/integration-tests/regression.test.js
+++ b/integration-tests/regression.test.js
@@ -44,4 +44,18 @@ describe('Tram-One - regressions', () => {
 		// verify that effect update was triggered
 		expect(getByText(container, 'Was Locked: true')).toBeVisible()
 	})
+
+	it('should process state as an array', async () => {
+		// start the app
+		const { container } = startApp()
+
+		// previously when state was being processed, it would be converted to an object
+		// this test adds an element to a store to verify array methods work
+
+		// `push` a new element on to a store
+		fireEvent.click(getByText(container, 'Add New Task'))
+
+		// expect the element to appear in the app
+		expect(getByText(container, 'Task Number 0')).toBeVisible()
+	})
 })

--- a/integration-tests/test-app/index.js
+++ b/integration-tests/test-app/index.js
@@ -6,7 +6,8 @@ const html = registerHtml({
 	'click-tracker': require('./click-tracker'),
 	'startup-wait': require('./startup-wait'),
 	'tab': require('./tab'),
-	'account': require('./account')
+	'account': require('./account'),
+	'tasks': require('./tasks')
 })
 
 /**
@@ -22,6 +23,7 @@ const app = () => {
 			<click-tracker />
 			<startup-wait />
 			<tab />
+			<tasks />
 		</main>
 	`
 }

--- a/integration-tests/test-app/tasks.js
+++ b/integration-tests/test-app/tasks.js
@@ -1,0 +1,23 @@
+const { registerHtml, useStore } = require('../../src/tram-one')
+
+const html = registerHtml()
+
+/**
+ * component to test url parameters
+ */
+module.exports = () => {
+	const tasks = useStore([])
+	const addTask = () => {
+		tasks.push(`Task Number ${tasks.length}`)
+	}
+
+	const taskList = tasks.map(task => html`<li>${task}</li>`)
+	return html`
+		<div>
+			<button onclick=${addTask}>Add New Task</button>
+			<ul>
+				${taskList}
+			</ul>
+		</div>
+	`
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "tram-one",
-  "version": "10.0.0",
+  "version": "10.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "10.0.0",
+      "version": "10.0.1",
       "license": "MIT",
       "dependencies": {
         "@nx-js/observer-util": "^4.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tram-one",
-  "version": "10.0.0",
+  "version": "10.0.1",
   "description": "🚋 Modern View Framework for Vanilla Javascript",
   "main": "dist/tram-one.cjs.js",
   "commonjs": "dist/tram-one.cjs.js",

--- a/src/observable-hook.js
+++ b/src/observable-hook.js
@@ -32,7 +32,8 @@ module.exports = (key, value) => {
 	// saves value into the store if it doesn't exist in the observableStore yet
 	// and if the value we are writing is defined
 	if (!Object.prototype.hasOwnProperty.call(observableStore, resolvedKey) && value !== undefined) {
-		observableStore[resolvedKey] = { ...value }
+		// save the value as a shallow copy of the parameter passed in
+		observableStore[resolvedKey] = Array.isArray(value) ? [...value] : { ...value }
 	}
 
 	// get value for key

--- a/src/use-global-store.js
+++ b/src/use-global-store.js
@@ -10,7 +10,7 @@ const observableHook = require('./observable-hook')
  * it will cause only the components that are dependent on that value to update.
  *
  * @param {string} key a unique string to write and read the global value
- * @param {Object|Array} value the default value to start the state at
+ * @param {Object|Array} defaultValue the default value to start the store at
  *
  * @returns {Object|Array} the store to interact with.
  */

--- a/src/use-store.js
+++ b/src/use-store.js
@@ -9,7 +9,7 @@ const observableHook = require('./observable-hook')
  * If the subfield of an object, or element of an array is updated
  * it will cause only the components that are dependent on that value to update.
  *
- * @param {Object|Array} value the default value to start the state at
+ * @param {Object|Array} defaultValue the default value to start the store at
  *
  * @returns {Object|Array} the store to interact with.
  */


### PR DESCRIPTION
## Summary

In the release of v10, the ability to store arrays was broken (because to make a shallow copy, the spread syntax for objects was used, but this inadvertently changed arrays to objects). There was no regression test for this, so a new one has been added. 


## Checklist
- [x] PR Summary
- [x] Tests
- [x] Version Bump
