### PR TITLE
Fix Initial useUrlParams bug

### DIFF
--- a/docs/badges/cjs.svg
+++ b/docs/badges/cjs.svg
@@ -14,7 +14,7 @@
   <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
     <text x="16.5" y="15" fill="#010101" fill-opacity=".3">cjs</text>
     <text x="16.5" y="14">cjs</text>
-    <text x="59" y="15" fill="#010101" fill-opacity=".3">25.83 kB</text>
-    <text x="59" y="14">25.83 kB</text>
+    <text x="59" y="15" fill="#010101" fill-opacity=".3">25.74 kB</text>
+    <text x="59" y="14">25.74 kB</text>
   </g>
 </svg>

--- a/docs/badges/umd.svg
+++ b/docs/badges/umd.svg
@@ -14,7 +14,7 @@
   <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
     <text x="16.5" y="15" fill="#010101" fill-opacity=".3">umd</text>
     <text x="16.5" y="14">umd</text>
-    <text x="59" y="15" fill="#010101" fill-opacity=".3">20.50 kB</text>
-    <text x="59" y="14">20.50 kB</text>
+    <text x="59" y="15" fill="#010101" fill-opacity=".3">20.49 kB</text>
+    <text x="59" y="14">20.49 kB</text>
   </g>
 </svg>

--- a/integration-tests/integration.test.js
+++ b/integration-tests/integration.test.js
@@ -136,13 +136,13 @@ describe('Tram-One', () => {
 		expect(getByText(container, 'Account: No Account Info')).toBeVisible()
 		expect(getByText(container, 'Is Account Logged In: No')).toBeVisible()
 
-		// set the add the account
+		// set the account in the url params
 		window.history.pushState({}, '', '/test_account')
 
 		// verify the account info updated
 		expect(getByText(container, 'Account: test_account')).toBeVisible()
 
-		// set the add the logged in value
+		// set the query parameter loggedIn
 		window.history.pushState({}, '', '/test_account?loggedIn=Yes')
 
 		// verify the account info updated

--- a/integration-tests/regression.test.js
+++ b/integration-tests/regression.test.js
@@ -60,14 +60,15 @@ describe('Tram-One - regressions', () => {
 	})
 
 	it('should read the url state on loading the app', async () => {
-		// previously when the app started, the incorrect url information was read
-		// set the add the account
+		// previously when the app started, the incorrect url information was being retrieved by the hook
+
+		// set the account in the url params
 		window.history.pushState({}, '', '/test_account')
 
 		// start the app
 		const { container } = startApp()
 
-		// verify the account info updated
+		// verify the account info is read correctly at startup
 		expect(getByText(container, 'Account: test_account')).toBeVisible()
 	})
 })

--- a/integration-tests/regression.test.js
+++ b/integration-tests/regression.test.js
@@ -58,4 +58,16 @@ describe('Tram-One - regressions', () => {
 		// expect the element to appear in the app
 		expect(getByText(container, 'Task Number 0')).toBeVisible()
 	})
+
+	it('should read the url state on loading the app', async () => {
+		// previously when the app started, the incorrect url information was read
+		// set the add the account
+		window.history.pushState({}, '', '/test_account')
+
+		// start the app
+		const { container } = startApp()
+
+		// verify the account info updated
+		expect(getByText(container, 'Account: test_account')).toBeVisible()
+	})
 })

--- a/integration-tests/test-app/account.js
+++ b/integration-tests/test-app/account.js
@@ -6,10 +6,10 @@ const html = registerHtml()
  * component to test url parameters
  */
 module.exports = () => {
-	const { account = 'No Account Info', loggedIn = 'No' } = useUrlParams('/:account')
+	const { account, loggedIn = 'No' } = useUrlParams('/:account')
 	return html`
 		<div>
-			<p class="account">Account: ${account}</p>
+			<p class="account">Account: ${account ? account : 'No Account Info'}</p>
 			<p class="account">Is Account Logged In: ${loggedIn}</p>
 		</div>
 	`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "tram-one",
-  "version": "10.0.2",
+  "version": "10.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "10.0.2",
+      "version": "10.0.3",
       "license": "MIT",
       "dependencies": {
         "@nx-js/observer-util": "^4.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tram-one",
-  "version": "10.0.2",
+  "version": "10.0.3",
   "description": "🚋 Modern View Framework for Vanilla Javascript",
   "main": "dist/tram-one.cjs.js",
   "commonjs": "dist/tram-one.cjs.js",

--- a/src/use-url-params.js
+++ b/src/use-url-params.js
@@ -23,15 +23,14 @@ module.exports = pattern => {
 	// save and update results in an observable, so that we can update
 	// components and effects in a reactive way
 	const initialParams = useUrlParams(pattern)
-	const observedUrlParams = useStore({ params: initialParams })
+	const observedUrlParams = useStore(initialParams)
 
 	// urlListener can re-read the route and save the new results to the observable
 	urlListener(() => {
 		const updatedParams = useUrlParams(pattern)
 
-		// in cases where useUrlParams returned false, set with the new value
 		// get all keys so we can override new and old ones (without having to override the whole object)
-		const allParamKeys = [...Object.keys(observedUrlParams), ...Object.keys(updatedParams)]
+		const allParamKeys = [...Object.keys(initialParams), ...Object.keys(updatedParams)]
 		allParamKeys.forEach(paramKey => {
 			observedUrlParams[paramKey] = updatedParams[paramKey]
 		})


### PR DESCRIPTION
## Summary
There is a bug in the existing version of Tram-One, where on initial load, the url parameters live in a `params` field. This is only true for the first render, and then afterwards works as expected (with keys at the top level). 

This PR fixes the issue, and adds a regression test to verify the behavior acts as expected.

## Checklist
- [x] PR Summary
- [x] Tests
- [x] Version Bump
