### PR TITLE
Remove focus marker on elements

### DIFF
--- a/docs/badges/cjs.svg
+++ b/docs/badges/cjs.svg
@@ -14,7 +14,7 @@
   <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
     <text x="16.5" y="15" fill="#010101" fill-opacity=".3">cjs</text>
     <text x="16.5" y="14">cjs</text>
-    <text x="59" y="15" fill="#010101" fill-opacity=".3">28.02 kB</text>
-    <text x="59" y="14">28.02 kB</text>
+    <text x="59" y="15" fill="#010101" fill-opacity=".3">28.11 kB</text>
+    <text x="59" y="14">28.11 kB</text>
   </g>
 </svg>

--- a/docs/badges/umd.svg
+++ b/docs/badges/umd.svg
@@ -14,7 +14,7 @@
   <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
     <text x="16.5" y="15" fill="#010101" fill-opacity=".3">umd</text>
     <text x="16.5" y="14">umd</text>
-    <text x="59" y="15" fill="#010101" fill-opacity=".3">21.09 kB</text>
-    <text x="59" y="14">21.09 kB</text>
+    <text x="59" y="15" fill="#010101" fill-opacity=".3">21.16 kB</text>
+    <text x="59" y="14">21.16 kB</text>
   </g>
 </svg>

--- a/integration-tests/regression.test.js
+++ b/integration-tests/regression.test.js
@@ -112,5 +112,55 @@ describe('Tram-One - regressions', () => {
 		await waitFor(() => {
 			expect(getByLabelText(appContainer, 'New Task Label')).toHaveFocus()
 		})
+
+		// cleanup - remove app
+		appContainer.remove()
+	})
+
+	it('should keep focus on the most recent input when components rerender', async () => {
+		// for focus to work correctly, the element needs to be attached to the document
+		const appContainer = document.createElement('div')
+		appContainer.id = 'app'
+		window.document.body.appendChild(appContainer)
+
+		// start the app using a css selector
+		startApp('#app')
+
+		// previously when interacting with an input, if the component would rerender
+		// focus would be removed from the component and put on the body of the page
+
+		// focus on the first input
+		userEvent.click(getByLabelText(appContainer, 'New Task Label'))
+
+		// focus on the second input
+		userEvent.click(getByLabelText(appContainer, 'New Task Type'))
+
+		// verify that the element has focus (before we start changing text)
+		await waitFor(() => {
+			expect(getByLabelText(appContainer, 'New Task Type')).toHaveFocus()
+		})
+
+		// clear the input
+		userEvent.type(getByLabelText(appContainer, 'New Task Type'), '{selectall}{backspace}')
+
+		// wait for mutation observer to reapply focus
+		await waitFor(() => {
+			expect(getByLabelText(appContainer, 'New Task Type')).toHaveFocus()
+		})
+
+		// update the state by typing
+		userEvent.type(getByLabelText(appContainer, 'New Task Type'), '0')
+
+		// verify the element has the new value
+		expect(getByLabelText(appContainer, 'New Task Type')).toHaveValue('0')
+
+		// wait for mutation observer to re-attach focus
+		// expect the input to keep focus after the change event
+		await waitFor(() => {
+			expect(getByLabelText(appContainer, 'New Task Type')).toHaveFocus()
+		})
+
+		// cleanup - remove app
+		appContainer.remove()
 	})
 })

--- a/integration-tests/test-app/tasks.js
+++ b/integration-tests/test-app/tasks.js
@@ -7,7 +7,7 @@ const html = registerHtml()
  */
 module.exports = () => {
 	const tasks = useStore([])
-	const newTask = useStore({ label: `Task Number ${tasks.length}` })
+	const newTask = useStore({ label: `Task Number ${tasks.length}`, type: 'Projects' })
 
 	const addTask = () => {
 		tasks.push(newTask.label)
@@ -17,12 +17,19 @@ module.exports = () => {
 		newTask.label = event.target.value
 	}
 
+	const updateNewTaskType = event => {
+		newTask.type = event.target.value
+	}
+
 	const taskList = tasks.map(task => html`<li>${task}</li>`)
 	return html`
 		<div>
 			<label for="new-task-label">New Task Label</label>
 			<p>${newTask.label.length} / 255</p>
 			<input id="new-task-label" name="new-task-label" value=${newTask.label} oninput=${updateNewTask} tabindex="0" />
+			<label for="new-task-type">New Task Type</label>
+			<p>${newTask.type.length} / 255</p>
+			<input id="new-task-type" name="new-task-type" value=${newTask.type} oninput=${updateNewTaskType} tabindex="0" />
 			<button onclick=${addTask}>Add New Task</button>
 			<ul>
 				${taskList}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "tram-one",
-  "version": "10.1.0",
+  "version": "10.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "10.1.0",
+      "version": "10.1.1",
       "license": "MIT",
       "dependencies": {
         "@nx-js/observer-util": "^4.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tram-one",
-  "version": "10.1.0",
+  "version": "10.1.1",
   "description": "🚋 Modern View Framework for Vanilla Javascript",
   "main": "dist/tram-one.cjs.js",
   "commonjs": "dist/tram-one.cjs.js",

--- a/src/start-focus-tracker.js
+++ b/src/start-focus-tracker.js
@@ -5,8 +5,14 @@ const { TRAM_TAG_FOCUS } = require('./node-names')
  */
 module.exports = container => {
 	// add event listener that marks a tag as having had focus
-	// when there is a clear example, we'll probably want to cleanup and remove the attribute
 	container.addEventListener('focusin', event => {
 		event.target[TRAM_TAG_FOCUS] = true
+	})
+
+	// add event listener that unmarks a tag as having had focus
+	container.addEventListener('focusout', event => {
+		if (event.relatedTarget) {
+			event.target[TRAM_TAG_FOCUS] = false
+		}
 	})
 }


### PR DESCRIPTION
## Summary

Previously, when interacting with multiple inputs, focus would be thrown onto the wrong element when the component refreshed. This PR removes the focus marker when the `focusout` event occurs.

## Checklist
- [x] PR Summary
- [x] Tests
- [x] Version Bump
