### PR TITLE
Include runkit example in npm distributable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,14 @@
 {
   "name": "tram-one",
-  "version": "10.1.3",
+  "version": "10.1.4",
   "description": "🚋 Modern View Framework for Vanilla Javascript",
   "main": "dist/tram-one.cjs.js",
   "commonjs": "dist/tram-one.cjs.js",
   "umd": "dist/tram-one.umd.js",
   "files": [
     "dist/tram-one.cjs.js",
-    "dist/tram-one.umd.js"
+    "dist/tram-one.umd.js",
+    "docs/runkit_example.js"
   ],
   "scripts": {
     "lint": "xo",


### PR DESCRIPTION
## Summary
Update the `package.json` to include the runkit example in the npm package. 
I believe including this document in the npm package will allow RunKit to pick up the file (whereas it currently can not find the file).

## Checklist
- [x] PR Summary
- [ ] Tests
- [x] Version Bump
