### PR TITLE
Fix input focus on re-ordered elements

### DIFF
--- a/docs/badges/cjs.svg
+++ b/docs/badges/cjs.svg
@@ -14,7 +14,7 @@
   <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
     <text x="16.5" y="15" fill="#010101" fill-opacity=".3">cjs</text>
     <text x="16.5" y="14">cjs</text>
-    <text x="59" y="15" fill="#010101" fill-opacity=".3">27.59 kB</text>
-    <text x="59" y="14">27.59 kB</text>
+    <text x="59" y="15" fill="#010101" fill-opacity=".3">29.14 kB</text>
+    <text x="59" y="14">29.14 kB</text>
   </g>
 </svg>

--- a/docs/badges/cjs.svg
+++ b/docs/badges/cjs.svg
@@ -14,7 +14,7 @@
   <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
     <text x="16.5" y="15" fill="#010101" fill-opacity=".3">cjs</text>
     <text x="16.5" y="14">cjs</text>
-    <text x="59" y="15" fill="#010101" fill-opacity=".3">28.96 kB</text>
-    <text x="59" y="14">28.96 kB</text>
+    <text x="59" y="15" fill="#010101" fill-opacity=".3">29.15 kB</text>
+    <text x="59" y="14">29.15 kB</text>
   </g>
 </svg>

--- a/docs/badges/cjs.svg
+++ b/docs/badges/cjs.svg
@@ -14,7 +14,7 @@
   <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
     <text x="16.5" y="15" fill="#010101" fill-opacity=".3">cjs</text>
     <text x="16.5" y="14">cjs</text>
-    <text x="59" y="15" fill="#010101" fill-opacity=".3">29.15 kB</text>
-    <text x="59" y="14">29.15 kB</text>
+    <text x="59" y="15" fill="#010101" fill-opacity=".3">29.33 kB</text>
+    <text x="59" y="14">29.33 kB</text>
   </g>
 </svg>

--- a/docs/badges/cjs.svg
+++ b/docs/badges/cjs.svg
@@ -14,7 +14,7 @@
   <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
     <text x="16.5" y="15" fill="#010101" fill-opacity=".3">cjs</text>
     <text x="16.5" y="14">cjs</text>
-    <text x="59" y="15" fill="#010101" fill-opacity=".3">29.14 kB</text>
-    <text x="59" y="14">29.14 kB</text>
+    <text x="59" y="15" fill="#010101" fill-opacity=".3">28.96 kB</text>
+    <text x="59" y="14">28.96 kB</text>
   </g>
 </svg>

--- a/docs/badges/umd.svg
+++ b/docs/badges/umd.svg
@@ -14,7 +14,7 @@
   <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
     <text x="16.5" y="15" fill="#010101" fill-opacity=".3">umd</text>
     <text x="16.5" y="14">umd</text>
-    <text x="59" y="15" fill="#010101" fill-opacity=".3">21.27 kB</text>
-    <text x="59" y="14">21.27 kB</text>
+    <text x="59" y="15" fill="#010101" fill-opacity=".3">21.33 kB</text>
+    <text x="59" y="14">21.33 kB</text>
   </g>
 </svg>

--- a/docs/badges/umd.svg
+++ b/docs/badges/umd.svg
@@ -14,7 +14,7 @@
   <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
     <text x="16.5" y="15" fill="#010101" fill-opacity=".3">umd</text>
     <text x="16.5" y="14">umd</text>
-    <text x="59" y="15" fill="#010101" fill-opacity=".3">21.02 kB</text>
-    <text x="59" y="14">21.02 kB</text>
+    <text x="59" y="15" fill="#010101" fill-opacity=".3">21.28 kB</text>
+    <text x="59" y="14">21.28 kB</text>
   </g>
 </svg>

--- a/docs/badges/umd.svg
+++ b/docs/badges/umd.svg
@@ -14,7 +14,7 @@
   <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
     <text x="16.5" y="15" fill="#010101" fill-opacity=".3">umd</text>
     <text x="16.5" y="14">umd</text>
-    <text x="59" y="15" fill="#010101" fill-opacity=".3">21.28 kB</text>
-    <text x="59" y="14">21.28 kB</text>
+    <text x="59" y="15" fill="#010101" fill-opacity=".3">21.27 kB</text>
+    <text x="59" y="14">21.27 kB</text>
   </g>
 </svg>

--- a/integration-tests/test-app/sub-mirror-input.js
+++ b/integration-tests/test-app/sub-mirror-input.js
@@ -8,14 +8,17 @@ const html = registerHtml({
  * component to test url parameters
  */
 module.exports = () => {
-	const mirrorable = useGlobalStore('mirrorable-input', { value: '' })
+	const mirrorable = useGlobalStore('mirrorable-input')
 
 	const onEvent = event => {
 		mirrorable.value = event.target.value
 	}
 
+	const letterSpans = [...Array(mirrorable.value.length)].map(() => html`<span class="letter-span">-</span>`)
+
 	return html`
 		<div>
+			${letterSpans}
 			<label for="sub-mirrorable-input">Sub Mirror Input</label>
 			<input id="sub-mirrorable-input" class="main input-component" type="text" value=${mirrorable.value} onkeyup=${onEvent} />
 		</div>

--- a/integration-tests/test-app/sub-mirror-input.js
+++ b/integration-tests/test-app/sub-mirror-input.js
@@ -14,7 +14,7 @@ module.exports = () => {
 		mirrorable.value = event.target.value
 	}
 
-	const letterSpans = [...Array(mirrorable.value.length)].map(() => html`<span class="letter-span">-</span>`)
+	const letterSpans = [...new Array(mirrorable.value.length)].map(() => html`<span class="letter-span">-</span>`)
 
 	return html`
 		<div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "tram-one",
-  "version": "10.1.5",
+  "version": "10.1.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "10.1.5",
+      "version": "10.1.6",
       "license": "MIT",
       "dependencies": {
         "@nx-js/observer-util": "^4.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tram-one",
-  "version": "10.1.5",
+  "version": "10.1.6",
   "description": "🚋 Modern View Framework for Vanilla Javascript",
   "main": "dist/tram-one.cjs.js",
   "commonjs": "dist/tram-one.cjs.js",

--- a/src/observe-tag.js
+++ b/src/observe-tag.js
@@ -1,15 +1,19 @@
 const { observe } = require('@nx-js/observer-util')
 const { TRAM_TAG_REACTION, TRAM_TAG_NEW_EFFECTS, TRAM_TAG_CLEANUP_EFFECTS } = require('./node-names')
 
-// helper functions for sorting
+// functions to go to nodes or indicies (made for .map)
 const toIndicies = (node, index) => index
-const toNodes = elementAndChildren => index => elementAndChildren[index]
+const toNodes = allNodes => index => allNodes[index]
+
+// sorting function that prioritizes indicies that are closest to a target
+// e.g. target = 3, [1, 2, 3, 4, 5] => [3, 2, 4, 1, 5]
 const byDistanceFromIndex = targetIndex => (indexA, indexB) => {
 	const diffFromTargetA = Math.abs(indexA - targetIndex)
 	const diffFromTargetB = Math.abs(indexB - targetIndex)
 	return diffFromTargetA < diffFromTargetB ? -1 : 1
 }
 
+// get an array including the element and all it's children
 const parentAndChildrenElements = node => {
 	const children = node.querySelectorAll('*')
 	return [node, ...children]

--- a/src/observe-tag.js
+++ b/src/observe-tag.js
@@ -10,6 +10,11 @@ const byDistanceFromIndex = targetIndex => (indexA, indexB) => {
 	return diffFromTargetA < diffFromTargetB ? -1 : 1
 }
 
+const parentAndChildrenElements = node => {
+	const children = node.querySelectorAll('*')
+	return [node, ...children]
+}
+
 /**
  * This is a helper function for the dom creation.
  * This function observes any state values used when making the tag, and allow it to update
@@ -27,23 +32,27 @@ module.exports = tagFunction => {
 			tagName: null,
 			selectionStart: null,
 			selectionEnd: null,
-			selectionDirection: null
+			selectionDirection: null,
+			scrollLeft: null
 		}
 
 		// remove oldTag first so that we unobserve before we re-observe
 		if (oldTag) {
 			// if there was focus, we need to figure out what element has it
-			const children = oldTag.querySelectorAll('*')
-			const parentAndChildrenNodes = [oldTag, ...children]
-			removedElementWithFocusData.index = parentAndChildrenNodes.findIndex(element => element === document.activeElement)
+			const allElements = parentAndChildrenElements(oldTag)
+			removedElementWithFocusData.index = allElements.findIndex(element => element === document.activeElement)
 
 			// if an element had focus, copy over all the selection data (so we can copy it back later)
 			if (removedElementWithFocusData.index >= 0) {
-				const removedElementWithFocus = parentAndChildrenNodes[removedElementWithFocusData.index]
+				// get the actual element
+				const removedElementWithFocus = allElements[removedElementWithFocusData.index]
+
+				// copy over the data
 				removedElementWithFocusData.tagName = removedElementWithFocus.tagName
 				removedElementWithFocusData.selectionStart = removedElementWithFocus.selectionStart
 				removedElementWithFocusData.selectionEnd = removedElementWithFocus.selectionEnd
 				removedElementWithFocusData.selectionDirection = removedElementWithFocus.selectionDirection
+				removedElementWithFocusData.scrollLeft = removedElementWithFocus.scrollLeft
 			}
 
 			const emptyDiv = document.createElement('div')
@@ -67,29 +76,17 @@ module.exports = tagFunction => {
 
 			// if an element had focus, reapply it
 			if (removedElementWithFocusData.index >= 0) {
-				const children = tagResult.querySelectorAll('*')
-				const elementAndChildren = [tagResult, ...children]
+				const allElements = parentAndChildrenElements(tagResult)
 
-				const newElementAtIndex = elementAndChildren[removedElementWithFocusData.index]
-				const newElementAtIndexMatches = newElementAtIndex && (elementAndChildren[removedElementWithFocusData.index].tagName === removedElementWithFocusData.tagName)
-
-				let elementToGiveFocus
-
-				// if the elementAtIndex matches, set that to be the element to give focus
-				if (newElementAtIndexMatches) {
-					elementToGiveFocus = newElementAtIndex
-				}
-
-				// if the tagName doesn't match (or exist), it means the number of children probably changed...
-				// we can still try to find it though, we'll look through the children (in order of nodes closest to original index) and find a tag that matches
+				// we'll look through the elements (in order of nodes closest to original index) and find a tag that matches.
+				// this means if it didn't move, we'll get it right away,
+				// if it did, we'll look at the elements closest to the original position
 				const nodeMatchesTagName = node => node.tagName === removedElementWithFocusData.tagName
-				if (!newElementAtIndexMatches) {
-					elementToGiveFocus = elementAndChildren
-						.map(toIndicies)
-						.sort(byDistanceFromIndex(removedElementWithFocusData.index))
-						.map(toNodes(elementAndChildren))
-						.find(nodeMatchesTagName)
-				}
+				const elementToGiveFocus = allElements
+					.map(toIndicies)
+					.sort(byDistanceFromIndex(removedElementWithFocusData.index))
+					.map(toNodes(allElements))
+					.find(nodeMatchesTagName)
 
 				// if the element / child exists, focus it
 				if (elementToGiveFocus !== undefined) {
@@ -104,6 +101,9 @@ module.exports = tagFunction => {
 							removedElementWithFocusData.selectionDirection
 						)
 					}
+
+					// also set the scrollLeft (since this is reset to 0 by default)
+					elementToGiveFocus.scrollLeft = removedElementWithFocusData.scrollLeft
 				}
 			}
 

--- a/src/observe-tag.js
+++ b/src/observe-tag.js
@@ -10,7 +10,7 @@ const toNodes = allNodes => index => allNodes[index]
 const byDistanceFromIndex = targetIndex => (indexA, indexB) => {
 	const diffFromTargetA = Math.abs(indexA - targetIndex)
 	const diffFromTargetB = Math.abs(indexB - targetIndex)
-	return diffFromTargetA < diffFromTargetB ? -1 : 1
+	return diffFromTargetA - diffFromTargetB
 }
 
 // get an array including the element and all it's children

--- a/src/observe-tag.js
+++ b/src/observe-tag.js
@@ -37,7 +37,8 @@ module.exports = tagFunction => {
 			selectionStart: null,
 			selectionEnd: null,
 			selectionDirection: null,
-			scrollLeft: null
+			scrollLeft: null,
+			scrollTop: null
 		}
 
 		// remove oldTag first so that we unobserve before we re-observe
@@ -57,6 +58,7 @@ module.exports = tagFunction => {
 				removedElementWithFocusData.selectionEnd = removedElementWithFocus.selectionEnd
 				removedElementWithFocusData.selectionDirection = removedElementWithFocus.selectionDirection
 				removedElementWithFocusData.scrollLeft = removedElementWithFocus.scrollLeft
+				removedElementWithFocusData.scrollTop = removedElementWithFocus.scrollTop
 			}
 
 			const emptyDiv = document.createElement('div')
@@ -106,8 +108,9 @@ module.exports = tagFunction => {
 						)
 					}
 
-					// also set the scrollLeft (since this is reset to 0 by default)
+					// also set the scrollLeft and scrollTop (since this is reset to 0 by default)
 					elementToGiveFocus.scrollLeft = removedElementWithFocusData.scrollLeft
+					elementToGiveFocus.scrollTop = removedElementWithFocusData.scrollTop
 				}
 			}
 

--- a/src/observe-tag.js
+++ b/src/observe-tag.js
@@ -3,8 +3,8 @@ const { TRAM_TAG_REACTION, TRAM_TAG_NEW_EFFECTS, TRAM_TAG_CLEANUP_EFFECTS } = re
 
 // helper functions for sorting
 const toIndicies = (node, index) => index
-const toNodes = (elementAndChildren) => (index) => elementAndChildren[index]
-const byDistanceFromIndex = (targetIndex) => (indexA, indexB) => {
+const toNodes = elementAndChildren => index => elementAndChildren[index]
+const byDistanceFromIndex = targetIndex => (indexA, indexB) => {
 	const diffFromTargetA = Math.abs(indexA - targetIndex)
 	const diffFromTargetB = Math.abs(indexB - targetIndex)
 	return diffFromTargetA < diffFromTargetB ? -1 : 1


### PR DESCRIPTION
## Summary
Fixes an issue where if the elements were re-ordered or changed significantly, we wouldn't be able to re-attach focus. Worse so, we never check if the element exists before trying to focus it, so we would get an error!

This PR also fixes an error where the scroll position would be reset when typing in an input. 

## Screenshots (Before)
When interacting with an input that has `<span>-</span>` for every letter in the input. This is what happens when typing and then deleting (this is the integration test app, which can be run locally with `npm run test:app`):
![image](https://user-images.githubusercontent.com/326557/126073068-e9367634-4f6f-4fd7-bf45-6a8507ec05d5.png)
The first set of errors is because we are trying to `setSelectionRange` on a `<span>`, the second error is because after deleting no element exists at the index that the `<input>` was on.

## Screenshots (After)
No errors :tada: 
![image](https://user-images.githubusercontent.com/326557/126073190-c61f90c9-d507-4e43-ab41-d9fa08bf0ba0.png)

## Checklist
- [x] PR Summary
- [x] Tests
- [x] Version Bump
