### PR TITLE
initial work for adding performance tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "tram-one",
-  "version": "10.1.7",
+  "version": "10.1.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "10.1.7",
+      "version": "10.1.8",
       "license": "MIT",
       "dependencies": {
         "@nx-js/observer-util": "^4.2.2",

--- a/package.json
+++ b/package.json
@@ -20,9 +20,11 @@
     "watch:lint": "watch \"npm run lint\" src",
     "watch:build": "watch \"npm run build\" src",
     "clean": "git clean -Xdf",
-    "test": "jest --watch",
-    "test:ci": "jest --coverage",
+    "test": "jest integration-tests --watch",
+    "test:ci": "jest integration-tests --coverage",
     "test:app": "parcel integration-tests/test-app/index.html",
+    "test:performance": "jest performance-tests --watch --update-snapshot",
+    "test:performance:app": "parcel performance-tests/test-app/index.html",
     "start": "npm i && npm run build",
     "restart": "npm run clean && npm start"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tram-one",
-  "version": "10.1.7",
+  "version": "10.1.8",
   "description": "🚋 Modern View Framework for Vanilla Javascript",
   "main": "dist/tram-one.cjs.js",
   "commonjs": "dist/tram-one.cjs.js",

--- a/performance-tests/__snapshots__/performance.test.js.snap
+++ b/performance-tests/__snapshots__/performance.test.js.snap
@@ -3,34 +3,34 @@
 exports[`Tram-One - Performance Tests should render lots of elements quickly 1`] = `
 Object {
   "0010": Object {
-    "averageTime": 1.0707592200000091,
-    "maxTime": 2.0995399999999336,
-    "medianTime": 0.9903519999998025,
+    "averageTime": 1.2213466800000423,
+    "maxTime": 2.964711999999963,
+    "medianTime": 1.0390390000002299,
   },
   "0050": Object {
-    "averageTime": 1.9795256599999538,
-    "maxTime": 3.184698999999455,
-    "medianTime": 1.8801470000003064,
+    "averageTime": 2.090679160000009,
+    "maxTime": 5.007340000000113,
+    "medianTime": 1.9029090000003634,
   },
   "0100": Object {
-    "averageTime": 3.245847500000145,
-    "maxTime": 9.136802999999418,
-    "medianTime": 2.981826000000183,
+    "averageTime": 3.4207105600000975,
+    "maxTime": 4.558337000000392,
+    "medianTime": 3.0174210000004678,
   },
   "0500": Object {
-    "averageTime": 12.792782179999922,
-    "maxTime": 17.862021000000823,
-    "medianTime": 12.381100000000515,
+    "averageTime": 13.692366439999933,
+    "maxTime": 34.392783999999665,
+    "medianTime": 13.348606999999902,
   },
   "1000": Object {
-    "averageTime": 27.069117659999684,
-    "maxTime": 36.891797000000224,
-    "medianTime": 27.212838999999803,
+    "averageTime": 28.303497579999966,
+    "maxTime": 33.405838999999105,
+    "medianTime": 28.362035000001924,
   },
   "5000": Object {
-    "averageTime": 129.28729511999975,
-    "maxTime": 147.75103099999978,
-    "medianTime": 126.62713900000381,
+    "averageTime": 132.7851708800008,
+    "maxTime": 162.36070599999948,
+    "medianTime": 128.91566799999418,
   },
 }
 `;

--- a/performance-tests/__snapshots__/performance.test.js.snap
+++ b/performance-tests/__snapshots__/performance.test.js.snap
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Tram-One - Performance Tests should render lots of elements quickly 1`] = `
+Object {
+  "0010": Object {
+    "averageTime": 1.0707592200000091,
+    "maxTime": 2.0995399999999336,
+    "medianTime": 0.9903519999998025,
+  },
+  "0050": Object {
+    "averageTime": 1.9795256599999538,
+    "maxTime": 3.184698999999455,
+    "medianTime": 1.8801470000003064,
+  },
+  "0100": Object {
+    "averageTime": 3.245847500000145,
+    "maxTime": 9.136802999999418,
+    "medianTime": 2.981826000000183,
+  },
+  "0500": Object {
+    "averageTime": 12.792782179999922,
+    "maxTime": 17.862021000000823,
+    "medianTime": 12.381100000000515,
+  },
+  "1000": Object {
+    "averageTime": 27.069117659999684,
+    "maxTime": 36.891797000000224,
+    "medianTime": 27.212838999999803,
+  },
+  "5000": Object {
+    "averageTime": 129.28729511999975,
+    "maxTime": 147.75103099999978,
+    "medianTime": 126.62713900000381,
+  },
+}
+`;

--- a/performance-tests/performance.test.js
+++ b/performance-tests/performance.test.js
@@ -27,7 +27,7 @@ const testElementRenderer = async (container, count, renders) => {
 		expect(getByText(container, 'Render')).toHaveAttribute('renders', `${renders}`)
 	})
 
-	// will be "Wait: NN.NNNNNNNN"
+	// will be a string like "Wait: 12.3456789", and we just take the number
 	return getByText(container, /Wait/).innerHTML.split(' ')[1]
 }
 
@@ -59,11 +59,13 @@ describe('Tram-One - Performance Tests', () => {
 		// verify that the element-rendering test is up
 		expect(container).toHaveTextContent('Element Rendering Example')
 
+		// the number of elements that we will try to render
 		const elementCounts = ['0010', '0050', '0100', '0500', '1000', '5000']
 
-		// loop and log all the results
+		// store all the results in this object
 		const performanceResults = {}
 
+		// loop through all the number of elements that we want to test
 		let renderCount = 1
 		for (const counts of elementCounts) {
 			// initial render, to remove any lag associated with starting the app

--- a/performance-tests/performance.test.js
+++ b/performance-tests/performance.test.js
@@ -82,6 +82,17 @@ describe('Tram-One - Performance Tests', () => {
 			}
 		}
 
-		expect(getMeaningfulStats(performanceResults)).toMatchSnapshot()
+		// save results to a snapshot (these can be updated always)
+		// they are more of a reference to look back on
+		const stats = getMeaningfulStats(performanceResults)
+		expect(stats).toMatchSnapshot()
+
+		// what does quickly mean? 5x elements should not be more than 5x slower
+		// we'll use the median, since that is the least prone to error from outliers
+		// we'll also add a buffer to the right, to account for fragility
+		const buffer = 1 // 1 seconds, which will map to 5 seconds on the left
+		expect(stats['0050'].medianTime / 5).not.toBeGreaterThan(stats['0010'].medianTime + buffer)
+		expect(stats['0500'].medianTime / 5).not.toBeGreaterThan(stats['0100'].medianTime + buffer)
+		expect(stats['5000'].medianTime / 5).not.toBeGreaterThan(stats['1000'].medianTime + buffer)
 	})
 })

--- a/performance-tests/performance.test.js
+++ b/performance-tests/performance.test.js
@@ -1,0 +1,79 @@
+const { getByText, getByLabelText, fireEvent, waitFor } = require('@testing-library/dom')
+const { default: userEvent } = require('@testing-library/user-event')
+const { startApp } = require('./test-app')
+
+/**
+ * This function helps test the element-renderer page, by setting the count, and hitting the render button
+ * @returns how long it took to render the elements
+ */
+const testElementRenderer = async (container, count, renders) => {
+	// setup {count} elements
+	userEvent.type(getByLabelText(container, 'Element Count'), '{selectall}{backspace}')
+	userEvent.type(getByLabelText(container, 'Element Count'), `${count}`)
+
+	// verify the count is {count}
+	await waitFor(() => {
+		expect(getByLabelText(container, 'Element Count')).toHaveValue(`${count}`)
+	})
+
+	// click to trigger the render
+	userEvent.click(getByText(container, 'Render'))
+
+	// wait for the render button data to udpate
+	await waitFor(() => {
+		expect(getByText(container, 'Render')).toHaveAttribute('renders', `${renders}`)
+	})
+
+	// will be "Wait: NN.NNNNNNNN"
+	return getByText(container, /Wait/).innerHTML.split(' ')[1]
+}
+
+/**
+ * Takes in an object of performance metrics,
+ * and returns max times, median times, and average times
+ */
+const getMeaningfulStats = (performanceObject) => {
+	return Object.fromEntries(
+		Object.entries(performanceObject).map(([count, times]) => {
+			times.sort()
+
+			const maxTime = times.slice(-1)[0]
+			const medianTime = times[Math.floor(times.length/2)]
+			const averageTime = (times.reduce((sum, time) => sum + time))/(times.length)
+
+			return [count, { medianTime, averageTime, maxTime }]
+		})
+	)
+}
+
+describe('Tram-One - Performance Tests', () => {
+	it('should render lots of elements quickly', async () => {
+		// set the test to be element-rendering
+		window.history.pushState({}, '', '/element-rendering')
+
+		const {container} = startApp()
+
+		// verify that the element-rendering test is up
+		expect(container).toHaveTextContent('Element Rendering Example')
+
+		const elementCounts = ['0010', '0050', '0100', '0500', '1000', '5000']
+
+		// loop and log all the results
+		const performanceResults = {}
+
+		let renderCount = 1
+		for(counts of elementCounts) {
+			// initial render, to remove any lag associated with starting the app
+			await testElementRenderer(container, counts, renderCount)
+			performanceResults[counts] = []
+			const initialRenderCount = renderCount+1
+			const maxRenderCount = renderCount+50
+			for(renderCount = initialRenderCount; renderCount <= maxRenderCount; renderCount++) {
+				const result = await testElementRenderer(container, counts, renderCount)
+				performanceResults[counts].push(parseFloat(result))
+			}
+		}
+
+		expect(getMeaningfulStats(performanceResults)).toMatchSnapshot()
+	})
+})

--- a/performance-tests/test-app/element-rendering.js
+++ b/performance-tests/test-app/element-rendering.js
@@ -1,0 +1,36 @@
+const { registerHtml, useStore, useEffect } = require('../../src/tram-one')
+
+const html = registerHtml()
+
+/**
+ * This page has an input that changes the total number of elements on the page
+ */
+module.exports = () => {
+	const pageStore = useStore({ queue: '1000', elements: '1000', startTimer: 0, endTimer: 0, renders: 0 })
+
+	const updateCount = event => {
+		pageStore.queue = event.target.value
+	}
+
+	const render = () => {
+		pageStore.renders++
+		pageStore.startTimer = performance.now()
+		pageStore.elements = pageStore.queue
+		pageStore.endTimer = performance.now()
+	}
+
+	const numberOfElements = parseInt(pageStore.elements)
+	const elements = [...new Array(isNaN(numberOfElements) ? 0 : numberOfElements)].map(() => html`<span>-</span>`)
+
+	return html`
+		<section>
+			<h1>Element Rendering Example</h1>
+			<figure>Wait: ${pageStore.endTimer - pageStore.startTimer}</figure>
+			<label for="element-count">Element Count</label>
+			<input id="element-count" value=${pageStore.queue} onkeyup=${updateCount} />
+			<button onclick=${render} renders=${pageStore.renders}>Render</button>
+			<br />
+			${elements}
+		</section>
+	`
+}

--- a/performance-tests/test-app/element-rendering.js
+++ b/performance-tests/test-app/element-rendering.js
@@ -1,4 +1,4 @@
-const { registerHtml, useStore, useEffect } = require('../../src/tram-one')
+const { registerHtml, useStore } = require('../../src/tram-one')
 
 const html = registerHtml()
 
@@ -19,8 +19,8 @@ module.exports = () => {
 		pageStore.endTimer = performance.now()
 	}
 
-	const numberOfElements = parseInt(pageStore.elements)
-	const elements = [...new Array(isNaN(numberOfElements) ? 0 : numberOfElements)].map(() => html`<span>-</span>`)
+	const numberOfElements = Number.parseInt(pageStore.elements, 10)
+	const elements = [...new Array(Number.isNaN(numberOfElements) ? 0 : numberOfElements)].map(() => html`<span>-</span>`)
 
 	return html`
 		<section>

--- a/performance-tests/test-app/index.html
+++ b/performance-tests/test-app/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+	</head>
+	<body>
+		<div id="parcel-page"></div>
+		<script src="./index.js"></script>
+	</body>
+</html>

--- a/performance-tests/test-app/index.js
+++ b/performance-tests/test-app/index.js
@@ -2,7 +2,7 @@ const useUrlParams = require('use-url-params')
 const { registerHtml, start } = require('../../src/tram-one')
 
 const html = registerHtml({
-	'element-rendering': require('./element-rendering'),
+	'element-rendering': require('./element-rendering')
 })
 
 /**

--- a/performance-tests/test-app/index.js
+++ b/performance-tests/test-app/index.js
@@ -1,0 +1,49 @@
+const useUrlParams = require('use-url-params')
+const { registerHtml, start } = require('../../src/tram-one')
+
+const html = registerHtml({
+	'element-rendering': require('./element-rendering'),
+})
+
+/**
+ * main app to power integration tests
+ */
+const app = () => {
+	if (useUrlParams('/element-rendering').matches) return html`<div><element-rendering /></div>`
+	return html`
+		<main>
+			<h1>Performance Test App</h1>
+		</main>
+	`
+}
+
+const startApp = container => {
+	let appContainer = container
+	if (!appContainer) {
+		// before we setup the app, cleanup the document state if this was called before
+		const previousApp = document.querySelector('#app')
+		if (previousApp) previousApp.remove()
+
+		// setup the container for the app
+		appContainer = document.createElement('div')
+		appContainer.id = 'app'
+
+		// attach the container to the document
+		// this is required, since focus and visibility checks depend on being in the document
+		window.document.body.appendChild(appContainer)
+	}
+
+	start(app, appContainer)
+
+	return {
+		container: appContainer
+	}
+}
+
+if (document.querySelector('#parcel-page')) {
+	startApp('#parcel-page')
+}
+
+module.exports = {
+	app, startApp
+}


### PR DESCRIPTION
## Summary
Fixes #39 
This PR is an attempt to set up a framework for us to add tests that verify the performance of tram-one. All of the infrastructure is identical to the existing unit tests, but has uses performance timers and helper functions to get metrics of how slow tram-one was to update. It currently uses snapshots as artifacts of the timers.

## Checklist
- [x] PR Summary
- [x] Tests
- [x] Version Bump
