### PR TITLE
Update Badge Icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,6 @@
 <p align="center"><a href="http://tram-one.io/" target="_blank"><img src="https://unpkg.com/@tram-one/tram-logo@4" width="128"></a></p>
 
 <div align="center">
-  <a href="https://www.npmjs.com/package/tram-one">
-    <img src="https://img.shields.io/npm/dm/tram-one.svg" alt="Downloads">
-  </a>
-  <a href="https://www.npmjs.com/package/tram-one">
-    <img src="https://img.shields.io/npm/v/tram-one.svg" alt="Version">
-  </a>
-  <a href="https://www.npmjs.com/package/tram-one">
-    <img src="https://img.shields.io/npm/l/tram-one.svg" alt="License">
-  </a>
-</div>
-<div align="center">
   <a href="https://unpkg.com/tram-one/dist/tram-one.cjs">
     <img src="https://github.com/Tram-One/tram-one/raw/master/docs/badges/cjs.svg?sanitize=true" alt="Common JS build">
   </a>
@@ -21,7 +10,18 @@
   <a href="https://unpkg.com/tram-one/dist/tram-one.mjs">
     <img src="https://github.com/Tram-One/tram-one/raw/master/docs/badges/mjs.svg?sanitize=true" alt="ES Module build">
   </a>
-  <a href="https://discord.gg/dpBXAQC">
+</div>
+<div align="center">
+  <a href="https://www.npmjs.com/package/tram-one">
+    <img src="https://img.shields.io/npm/dm/tram-one.svg" alt="Downloads">
+  </a>
+  <a href="https://www.npmjs.com/package/tram-one">
+    <img src="https://img.shields.io/npm/v/tram-one.svg" alt="Version">
+  </a>
+  <a href="https://www.npmjs.com/package/tram-one">
+    <img src="https://img.shields.io/npm/l/tram-one.svg" alt="License">
+  </a>
+    <a href="https://discord.gg/dpBXAQC">
     <img src="https://img.shields.io/badge/discord-join-5865F2.svg?style=flat" alt="Join Discord">
   </a>
 </div>

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@
     <img src="https://github.com/Tram-One/tram-one/raw/master/docs/badges/umd.svg?sanitize=true" alt="UMD build">
   </a>
   <a href="https://unpkg.com/tram-one/dist/tram-one.mjs">
-    <img src="https://github.com/Tram-One/tram-one/raw/master/docs/badges/umd.svg?sanitize=true" alt="ES Module build">
+    <img src="https://github.com/Tram-One/tram-one/raw/master/docs/badges/mjs.svg?sanitize=true" alt="ES Module build">
   </a>
   <a href="https://discord.gg/dpBXAQC">
-    <img src="https://img.shields.io/badge/discord-join-83ded3.svg?style=flat" alt="Join Discord">
+    <img src="https://img.shields.io/badge/discord-join-5865F2.svg?style=flat" alt="Join Discord">
   </a>
 </div>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "tram-one",
-	"version": "12.0.1",
+	"version": "12.0.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "tram-one",
-			"version": "12.0.1",
+			"version": "12.0.2",
 			"license": "MIT",
 			"dependencies": {
 				"@nx-js/observer-util": "^4.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "tram-one",
-	"version": "12.0.1",
+	"version": "12.0.2",
 	"description": "🚋 Modern View Framework for Vanilla Javascript",
 	"main": "dist/tram-one.cjs",
 	"commonjs": "dist/tram-one.cjs",


### PR DESCRIPTION
## Summary
While building the org badges, I realized that we had pointed to the umd one twice. Additionally, decided to use a discord color for the discord one.

[You can see what the final result looks like here](https://github.com/Tram-One/tram-one/blob/update-badge-icons/README.md)

## Checklist
- [x] PR Summary
- [x] ~PR Annotations~
- [x] ~Tests~
- [x] Version Bump
