### PR TITLE
Type Updates - Tram One Generics

### DIFF
--- a/integration-tests/test-app/sub-title.ts
+++ b/integration-tests/test-app/sub-title.ts
@@ -5,7 +5,7 @@ const html = registerHtml();
 /**
  * component to test basic rendering
  */
-const subTitle: TramOneComponent = (props: any, children: Element) => {
+const subTitle: TramOneComponent = (props, children) => {
 	return html` <h2>${children}</h2> `;
 };
 

--- a/integration-tests/test-app/title.ts
+++ b/integration-tests/test-app/title.ts
@@ -1,4 +1,4 @@
-import { registerHtml, TramOneComponent, Props } from '../../src/tram-one';
+import { registerHtml, TramOneComponent } from '../../src/tram-one';
 import subtitle from './sub-title';
 
 const html = registerHtml({
@@ -9,7 +9,7 @@ const html = registerHtml({
 /**
  * component to test basic rendering
  */
-const title: TramOneComponent = ({ subtitle }: Props, children: Element) => {
+const title: TramOneComponent = ({ subtitle }, children) => {
 	return html`
 		<header>
 			<h1 class="title">Home Page</h1>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "tram-one",
-	"version": "12.0.2",
+	"version": "12.0.3",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "tram-one",
-			"version": "12.0.2",
+			"version": "12.0.3",
 			"license": "MIT",
 			"dependencies": {
 				"@nx-js/observer-util": "^4.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "tram-one",
-	"version": "12.0.2",
+	"version": "12.0.3",
 	"description": "🚋 Modern View Framework for Vanilla Javascript",
 	"main": "dist/tram-one.cjs",
 	"commonjs": "dist/tram-one.cjs",

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -14,7 +14,7 @@ import observeTag from './observe-tag';
 import processHooks from './process-hooks';
 import { TRAM_TAG, TRAM_TAG_NEW_EFFECTS, TRAM_TAG_CLEANUP_EFFECTS } from './node-names';
 
-import { Registry, Props, DOMTaggedTemplateFunction } from './types';
+import { Registry, Props, DOMTaggedTemplateFunction, Children } from './types';
 
 /**
  * This function takes in a namespace and registry of custom components,
@@ -29,7 +29,7 @@ export const registerDom = (namespace: string | null, registry: Registry = {}): 
 	// modify the registry so that each component function updates the hook working key
 	const hookedRegistry = Object.keys(registry).reduce((newRegistry, tagName) => {
 		const tagFunction = registry[tagName];
-		const hookedTagFunction = (props: Props, children: Element) => {
+		const hookedTagFunction = (props: Props, children?: Children) => {
 			// push a new branch onto the working key so any values that need to be unique among components
 			// but consistent across renders can be read
 			const stringifiedProps = JSON.stringify(props);

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -29,7 +29,7 @@ export const registerDom = (namespace: string | null, registry: Registry = {}): 
 	// modify the registry so that each component function updates the hook working key
 	const hookedRegistry = Object.keys(registry).reduce((newRegistry, tagName) => {
 		const tagFunction = registry[tagName];
-		const hookedTagFunction = (props: Props, children?: Children) => {
+		const hookedTagFunction = (props: Props, children: Children) => {
 			// push a new branch onto the working key so any values that need to be unique among components
 			// but consistent across renders can be read
 			const stringifiedProps = JSON.stringify(props);

--- a/src/mount.ts
+++ b/src/mount.ts
@@ -1,12 +1,12 @@
 import { registerHtml } from './dom-wrappers';
-import { Container, TramOneComponent } from './types';
+import { Container, RootTramOneComponent } from './types';
 
 /**
  * Updates a container with an initial component for the first render.
  * @param component the tram-one component to render
  * @param container an element to render the component on
  */
-export default (component: TramOneComponent, container: Container) => {
+export default (component: RootTramOneComponent, container: Container) => {
 	const html = registerHtml({
 		app: component,
 	});

--- a/src/start.ts
+++ b/src/start.ts
@@ -14,7 +14,7 @@ import { setupEffectStore } from './effect-store';
 import { setupWorkingKey } from './working-key';
 import { setupObservableStore } from './observable-store';
 import { setupMutationObserver, startWatcher } from './mutation-observer';
-import { ElementOrSelector, TramOneComponent } from './types';
+import { ElementOrSelector, RootTramOneComponent } from './types';
 import { setupKeyQueue } from './key-queue';
 import { setupKeyStore } from './key-store';
 
@@ -30,7 +30,7 @@ import { setupKeyStore } from './key-store';
  * @param component top-level component to attach to the page.
  * @param target either a CSS selector, or Node to attach the component to
  */
-export default (component: TramOneComponent, target: ElementOrSelector) => {
+export default (component: RootTramOneComponent, target: ElementOrSelector) => {
 	/* setup all the internal engines required for tram-one to work */
 
 	// get the container to mount the app on

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,7 +30,9 @@ export type DOMTaggedTemplateFunction = (
  * Type for custom Tram One Components.
  * They can take in props and children, and return some rendered Element.
  */
-export type TramOneComponent = [(props: Props, children: Element) => TramOneElement][0];
+export type TramOneComponent<PropsInterface extends Props = Props, ChildrenInterface extends Children = Children> = [
+	(props: PropsInterface, children: ChildrenInterface) => TramOneElement
+][0];
 
 /**
  * Type for useStore and useGlobalStore hooks.
@@ -65,12 +67,21 @@ export type Props = [
 ][0];
 
 /**
+ * The Children interface for custom Tram One Components.
+ * If the tag is self-closing, it will be `undefined`, otherwise it will
+ * be a list of strings and DOM Elements
+ */
+export type Children = [(Element | string)[] | undefined][0];
+
+/**
  * Type for registering Tram One Components in the template interface.
  * This is used in registerHtml and registerSvg.
  */
 export type Registry = [
 	{
-		[tag: string]: TramOneComponent;
+		// we use <any, any> here since in the Registry we can't be as explicit about the types being provided
+		// - for now lean on the end-user to know what types are required and passing them in
+		[tag: string]: TramOneComponent<any, any>;
 	}
 ][0];
 
@@ -96,6 +107,12 @@ export interface TramOneElement extends Element {
 	[TRAM_TAG_CLEANUP_EFFECTS]: CleanupEffect[];
 	[TRAM_TAG_STORE_KEYS]: string[];
 }
+
+/**
+ * Type for the Root TramOneComponent,
+ * it can have no props or children, since it is the root element
+ */
+export type RootTramOneComponent = TramOneComponent<{ [attribute: string]: never }, undefined>;
 
 /* ============= INTERNAL TYPES ========================================
  * These won't be exposed or really visible to end users.


### PR DESCRIPTION
## Summary
Update Tram-One types to use generics for component definitions! 

This mimics React's component prop type definitions.

## Version Update: Patch
This is a patch because it fixes a previously broken workflow. While this technically could introduce typescript errors where there weren't any before, those should be considered broken.

## Example
```ts
type pageHeaderProps = {
  index: number;
};

const pageHeader: TramOneComponent<pageHeaderProps> = ({ index }) => {
  const targetGroupPage = useTargetGroupPage(index);

  return html`
    <h1 class="page-header">
      <span>${targetGroupPage.title || ""}</span>
    </h1>
  `;
```

## Checklist
- [x] PR Summary
- [x] PR Annotations
- [x] ~Tests~
- [x] Version Bump
