### PR TITLE
Existing Effects & Refs

### DIFF
--- a/integration-tests/integration.test.js
+++ b/integration-tests/integration.test.js
@@ -156,4 +156,12 @@ describe('Tram-One', () => {
 		// verify the account info updated
 		expect(getByText(container, 'Is Account Logged In: Yes')).toBeVisible();
 	});
+
+	it('should process effects of components that return other components at root', () => {
+		// start the app
+		startApp();
+
+		// verify that effects were trigged
+		expect(window.location.hash).toBe('#testing');
+	});
 });

--- a/integration-tests/integration.test.js
+++ b/integration-tests/integration.test.js
@@ -1,4 +1,4 @@
-const { getByText, fireEvent, waitFor } = require('@testing-library/dom');
+const { getByText, fireEvent, waitFor, getByPlaceholderText } = require('@testing-library/dom');
 const { startApp } = require('./test-app');
 
 /**
@@ -163,5 +163,15 @@ describe('Tram-One', () => {
 
 		// verify that effects were trigged
 		expect(window.location.hash).toBe('#testing');
+	});
+
+	it('should process calculate the ref of elements in use-effects correctly', async () => {
+		// start the app
+		const { container } = startApp();
+
+		// verify the effect properly focused the input element
+		await waitFor(() => {
+			expect(getByPlaceholderText(container, 'Input for automatic focus')).toHaveFocus();
+		});
 	});
 });

--- a/integration-tests/integration.test.js
+++ b/integration-tests/integration.test.js
@@ -1,5 +1,6 @@
 const { getByText, fireEvent, waitFor, getByPlaceholderText } = require('@testing-library/dom');
 const { startApp } = require('./test-app');
+const { startAppAndWait } = require('./test-helpers');
 
 /**
  * The following tests are intentional test that validate the behavior of new features.
@@ -157,21 +158,11 @@ describe('Tram-One', () => {
 		expect(getByText(container, 'Is Account Logged In: Yes')).toBeVisible();
 	});
 
-	it('should process effects of components that return other components at root', () => {
-		// start the app
-		startApp();
-
-		// verify that effects were trigged
-		expect(window.location.hash).toBe('#testing');
-	});
-
 	it('should process effects on the element passed through use-effect', async () => {
 		// start the app
-		const { container } = startApp();
+		const { container } = await startAppAndWait();
 
 		// verify the effect properly focused the input element
-		await waitFor(() => {
-			expect(getByPlaceholderText(container, 'Input for automatic focus')).toHaveFocus();
-		});
+		expect(getByPlaceholderText(container, 'Input for automatic focus')).toHaveFocus();
 	});
 });

--- a/integration-tests/integration.test.js
+++ b/integration-tests/integration.test.js
@@ -165,7 +165,7 @@ describe('Tram-One', () => {
 		expect(window.location.hash).toBe('#testing');
 	});
 
-	it('should process calculate the ref of elements in use-effects correctly', async () => {
+	it('should process effects on the element passed through use-effect', async () => {
 		// start the app
 		const { container } = startApp();
 

--- a/integration-tests/regression.test.js
+++ b/integration-tests/regression.test.js
@@ -343,4 +343,15 @@ describe('Tram-One', () => {
 			expect(getByText(container, '[4: 0]')).toBeVisible();
 		});
 	});
+
+	it('should process effects of components that return other components at root', async () => {
+		// start the app
+		await startAppAndWait();
+
+		// previously if an element immediately returned another component,
+		// the effects of the child component would be lost
+
+		// verify that effects were trigged
+		expect(window.location.hash).toBe('#testing');
+	});
 });

--- a/integration-tests/regression.test.js
+++ b/integration-tests/regression.test.js
@@ -346,12 +346,13 @@ describe('Tram-One', () => {
 
 	it('should process effects of components that return other components at root', async () => {
 		// start the app
-		await startAppAndWait();
+		const { container } = await startAppAndWait();
 
 		// previously if an element immediately returned another component,
 		// the effects of the child component would be lost
 
 		// verify that effects were trigged
 		expect(window.location.hash).toBe('#testing');
+		expect(getByText(container, 'Anchor Set - effect triggered: true')).toBeVisible();
 	});
 });

--- a/integration-tests/test-app/anchor-set.ts
+++ b/integration-tests/test-app/anchor-set.ts
@@ -1,0 +1,15 @@
+import { registerHtml, useEffect, TramOneComponent } from '../../src/tram-one';
+
+const html = registerHtml();
+
+/**
+ * Element with a use effect (to test behavior when wrapped)
+ */
+const anchorSet: TramOneComponent = () => {
+	useEffect(() => {
+		window.location.hash = 'testing';
+	});
+	return html`<section />`;
+};
+
+export default anchorSet;

--- a/integration-tests/test-app/anchors.ts
+++ b/integration-tests/test-app/anchors.ts
@@ -9,8 +9,7 @@ const html = registerHtml({
  * Element to test behavior or wrapping a single component
  */
 const anchors: TramOneComponent = () => {
-	const params = useUrlParams('');
-	if (params.hash !== 'testing') return html`<anchor-set />`;
+	if (useUrlParams().hash !== 'testing') return html`<anchor-set />`;
 	return html`<section>Anchor Set</section>`;
 };
 

--- a/integration-tests/test-app/anchors.ts
+++ b/integration-tests/test-app/anchors.ts
@@ -1,0 +1,17 @@
+import { registerHtml, useUrlParams, TramOneComponent } from '../../src/tram-one';
+import anchorSet from './anchor-set';
+
+const html = registerHtml({
+	'anchor-set': anchorSet,
+});
+
+/**
+ * Element to test behavior or wrapping a single component
+ */
+const anchors: TramOneComponent = () => {
+	const params = useUrlParams('');
+	if (params.hash !== 'testing') return html`<anchor-set />`;
+	return html`<section>Anchor Set</section>`;
+};
+
+export default anchors;

--- a/integration-tests/test-app/anchors.ts
+++ b/integration-tests/test-app/anchors.ts
@@ -1,4 +1,4 @@
-import { registerHtml, useUrlParams, TramOneComponent } from '../../src/tram-one';
+import { registerHtml, useStore, useEffect, useUrlParams, TramOneComponent } from '../../src/tram-one';
 import anchorSet from './anchor-set';
 
 const html = registerHtml({
@@ -9,8 +9,13 @@ const html = registerHtml({
  * Element to test behavior or wrapping a single component
  */
 const anchors: TramOneComponent = () => {
+	const anchorStore = useStore({ effectTriggered: false });
+	useEffect(() => {
+		anchorStore.effectTriggered = true;
+	});
+
 	if (useUrlParams().hash !== 'testing') return html`<anchor-set />`;
-	return html`<section>Anchor Set</section>`;
+	return html`<section>Anchor Set - effect triggered: ${anchorStore.effectTriggered}</section>`;
 };
 
 export default anchors;

--- a/integration-tests/test-app/focus-input.ts
+++ b/integration-tests/test-app/focus-input.ts
@@ -7,7 +7,7 @@ const html = registerHtml();
  */
 const focusInput: TramOneComponent = () => {
 	useEffect((ref) => {
-		(ref as unknown as HTMLElement).focus();
+		ref.focus();
 	});
 	return html`<input placeholder="Input for automatic focus" />`;
 };

--- a/integration-tests/test-app/focus-input.ts
+++ b/integration-tests/test-app/focus-input.ts
@@ -5,11 +5,11 @@ const html = registerHtml();
 /**
  * Element to test useEffect reference point
  */
-const tramInput: TramOneComponent = () => {
+const focusInput: TramOneComponent = () => {
 	useEffect((ref) => {
 		(ref as unknown as HTMLElement).focus();
 	});
 	return html`<input placeholder="Input for automatic focus" />`;
 };
 
-export default tramInput;
+export default focusInput;

--- a/integration-tests/test-app/index.ts
+++ b/integration-tests/test-app/index.ts
@@ -10,6 +10,7 @@ import mirrorinput from './mirror-input';
 import documentTitleSetter from './document-title-setter';
 import elementstoregenerator from './element-store-generator';
 import { TramWindow } from '../../src/types';
+import anchors from './anchors';
 
 const html = registerHtml({
 	title: title,
@@ -22,6 +23,7 @@ const html = registerHtml({
 	'mirror-input': mirrorinput,
 	'document-title-setter': documentTitleSetter,
 	'element-store-generator': elementstoregenerator,
+	anchors: anchors,
 });
 
 /**
@@ -51,6 +53,7 @@ export const app = () => {
 			<tasks />
 			<mirror-input />
 			<element-store-generator />
+			<anchors />
 		</main>
 	`;
 };

--- a/integration-tests/test-app/index.ts
+++ b/integration-tests/test-app/index.ts
@@ -11,6 +11,7 @@ import documentTitleSetter from './document-title-setter';
 import elementstoregenerator from './element-store-generator';
 import { TramWindow } from '../../src/types';
 import anchors from './anchors';
+import tramInput from './tram-input';
 
 const html = registerHtml({
 	title: title,
@@ -24,6 +25,7 @@ const html = registerHtml({
 	'document-title-setter': documentTitleSetter,
 	'element-store-generator': elementstoregenerator,
 	anchors: anchors,
+	'tram-input': tramInput,
 });
 
 /**
@@ -43,6 +45,7 @@ export const app = () => {
 			<document-title-setter />
 
 			<title subtitle="Sub Title Prop">Sub Title Child</title>
+			<tram-input />
 			<p>Root Loaded: ${rootStore.loaded}</p>
 			<logo />
 			<account />

--- a/integration-tests/test-app/index.ts
+++ b/integration-tests/test-app/index.ts
@@ -11,7 +11,8 @@ import documentTitleSetter from './document-title-setter';
 import elementstoregenerator from './element-store-generator';
 import { TramWindow } from '../../src/types';
 import anchors from './anchors';
-import tramInput from './tram-input';
+import focusInput from './focus-input';
+import clickListenerContainer from './click-listener-container';
 
 const html = registerHtml({
 	title: title,
@@ -25,7 +26,7 @@ const html = registerHtml({
 	'document-title-setter': documentTitleSetter,
 	'element-store-generator': elementstoregenerator,
 	anchors: anchors,
-	'tram-input': tramInput,
+	'focus-input': focusInput,
 });
 
 /**
@@ -45,7 +46,7 @@ export const app = () => {
 			<document-title-setter />
 
 			<title subtitle="Sub Title Prop">Sub Title Child</title>
-			<tram-input />
+			<focus-input />
 			<p>Root Loaded: ${rootStore.loaded}</p>
 			<logo />
 			<account />

--- a/integration-tests/test-app/index.ts
+++ b/integration-tests/test-app/index.ts
@@ -12,7 +12,6 @@ import elementstoregenerator from './element-store-generator';
 import { TramWindow } from '../../src/types';
 import anchors from './anchors';
 import focusInput from './focus-input';
-import clickListenerContainer from './click-listener-container';
 
 const html = registerHtml({
 	title: title,

--- a/integration-tests/test-app/tram-input.ts
+++ b/integration-tests/test-app/tram-input.ts
@@ -1,0 +1,15 @@
+import { registerHtml, useEffect, TramOneComponent } from '../../src/tram-one';
+
+const html = registerHtml();
+
+/**
+ * Element to test useEffect reference point
+ */
+const tramInput: TramOneComponent = () => {
+	useEffect((ref) => {
+		(ref as unknown as HTMLElement).focus();
+	});
+	return html`<input placeholder="Input for automatic focus" />`;
+};
+
+export default tramInput;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "tram-one",
-	"version": "13.0.0",
+	"version": "13.1.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "tram-one",
-			"version": "13.0.0",
+			"version": "13.1.0",
 			"license": "MIT",
 			"dependencies": {
 				"@nx-js/observer-util": "^4.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "tram-one",
-	"version": "13.0.0",
+	"version": "13.1.0",
 	"description": "🚋 Modern View Framework for Vanilla Javascript",
 	"main": "dist/tram-one.cjs",
 	"commonjs": "dist/tram-one.cjs",

--- a/src/dom-wrappers.ts
+++ b/src/dom-wrappers.ts
@@ -1,6 +1,6 @@
 import { registerDom } from './dom';
 
-import { Registry } from './types';
+import { Registry, TramOneHTMLElement, TramOneSVGElement } from './types';
 
 /**
  * @name registerHtml
@@ -13,7 +13,7 @@ import { Registry } from './types';
  * @return tagged template function that builds HTML components
  */
 export const registerHtml = (registry?: Registry) => {
-	return registerDom(null, registry);
+	return registerDom<TramOneHTMLElement>(null, registry);
 };
 
 /**
@@ -26,5 +26,5 @@ export const registerHtml = (registry?: Registry) => {
  * @return tagged template function that builds SVG components
  */
 export const registerSvg = (registry?: Registry) => {
-	return registerDom('http://www.w3.org/2000/svg', registry);
+	return registerDom<TramOneSVGElement>('http://www.w3.org/2000/svg', registry);
 };

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -14,7 +14,7 @@ import observeTag from './observe-tag';
 import processHooks from './process-hooks';
 import { TRAM_TAG, TRAM_TAG_NEW_EFFECTS, TRAM_TAG_CLEANUP_EFFECTS } from './node-names';
 
-import { Registry, Props, DOMTaggedTemplateFunction, Children } from './types';
+import { Registry, Props, DOMTaggedTemplateFunction, Children, TramOneHTMLElement, TramOneSVGElement } from './types';
 
 /**
  * This function takes in a namespace and registry of custom components,
@@ -25,7 +25,10 @@ import { Registry, Props, DOMTaggedTemplateFunction, Children } from './types';
  * @param registry mapping of tag names to component functions
  * @param namespace namespace to create nodes in (by default XHTML namespace)
  */
-export const registerDom = (namespace: string | null, registry: Registry = {}): DOMTaggedTemplateFunction => {
+export const registerDom = <ElementType extends TramOneHTMLElement | TramOneSVGElement>(
+	namespace: string | null,
+	registry: Registry = {}
+) => {
 	// modify the registry so that each component function updates the hook working key
 	const hookedRegistry = Object.keys(registry).reduce((newRegistry, tagName) => {
 		const tagFunction = registry[tagName];
@@ -68,5 +71,5 @@ export const registerDom = (namespace: string | null, registry: Registry = {}): 
 		return { ...newRegistry, [tagName]: hookedTagFunction };
 	}, {});
 
-	return rbel(hyperx, nanohtml(namespace), hookedRegistry);
+	return rbel(hyperx, nanohtml(namespace), hookedRegistry) as DOMTaggedTemplateFunction<ElementType>;
 };

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -59,7 +59,8 @@ export const registerDom = (namespace: string | null, registry: Registry = {}): 
 			tagResult[TRAM_TAG] = true;
 			// we won't decorate TRAM_TAG_REACTION, that needs to be done later when we observe the tag
 			tagResult[TRAM_TAG_NEW_EFFECTS] = tagResult[TRAM_TAG_NEW_EFFECTS] || [];
-			tagResult[TRAM_TAG_CLEANUP_EFFECTS] = tagResult[TRAM_TAG_NEW_EFFECTS] || [];
+			// cleanup effects will be populated when new effects are processed
+			tagResult[TRAM_TAG_CLEANUP_EFFECTS] = [];
 
 			return tagResult;
 		};

--- a/src/mount.ts
+++ b/src/mount.ts
@@ -13,6 +13,6 @@ export default (component: RootTramOneComponent, container: Container) => {
 
 	// this sadly needs to be wrapped in some element so we can process effects
 	// otherwise the root node will not have effects applied on it
-	const renderedApp = html`<div><app /></div>`;
+	const renderedApp = html`<tram-one><app /></tram-one>`;
 	container.replaceChild(renderedApp, container.firstElementChild);
 };

--- a/src/mutation-observer.ts
+++ b/src/mutation-observer.ts
@@ -54,8 +54,8 @@ const processTramTags = (node: Node | TramOneElement) => {
 			// this is called when an effect is re-triggered
 			const effectReaction = observe(() => {
 				// verify that cleanup is a function before calling it (in case it was a promise)
-				if (typeof cleanup === 'function') cleanup();
-				cleanup = effect();
+				if (typeof cleanup === 'function') cleanup(node);
+				cleanup = effect(node);
 			});
 
 			// this is called when a component with an effect is removed
@@ -76,8 +76,9 @@ const processTramTags = (node: Node | TramOneElement) => {
 /**
  * call all cleanup effects on the node
  */
-const cleanupEffects = (cleanupEffects: (() => void)[]) => {
-	cleanupEffects.forEach((cleanup) => cleanup());
+const cleanupEffects = (node: TramOneElement) => {
+	const cleanupEffects = node[TRAM_TAG_CLEANUP_EFFECTS];
+	cleanupEffects.forEach((cleanup) => cleanup(node));
 };
 
 /**
@@ -114,7 +115,7 @@ const clearNode = (node: Node | TramOneElement) => {
 	}
 
 	unobserve(node[TRAM_TAG_REACTION]);
-	cleanupEffects(node[TRAM_TAG_CLEANUP_EFFECTS]);
+	cleanupEffects(node);
 	removeStoreKeyAssociation(node[TRAM_TAG_STORE_KEYS]);
 };
 

--- a/src/mutation-observer.ts
+++ b/src/mutation-observer.ts
@@ -16,7 +16,7 @@ import {
 	TRAM_TAG_STORE_KEYS,
 } from './node-names';
 import { buildNamespace } from './namespace';
-import { CleanupEffect, TramOneElement } from './types';
+import { CleanupEffect, TramOneElement, TramOneHTMLElement, TramOneSVGElement } from './types';
 import { getObservableStore } from './observable-store';
 import { TRAM_OBSERVABLE_STORE, TRAM_KEY_STORE } from './engine-names';
 import { decrementKeyStoreValue, getKeyStore, incrementKeyStoreValue } from './key-store';
@@ -25,7 +25,7 @@ import { decrementKeyStoreValue, getKeyStore, incrementKeyStoreValue } from './k
  * process side-effects for new tram-one nodes
  * (this includes calling effects, and keeping track of stores)
  */
-const processTramTags = (node: Node | TramOneElement) => {
+const processTramTags = (node: Node | (TramOneHTMLElement | TramOneSVGElement)) => {
 	// if this element doesn't have a TRAM_TAG, it's not a Tram-One Element
 	if (!(TRAM_TAG in node)) {
 		return;

--- a/src/mutation-observer.ts
+++ b/src/mutation-observer.ts
@@ -16,7 +16,7 @@ import {
 	TRAM_TAG_STORE_KEYS,
 } from './node-names';
 import { buildNamespace } from './namespace';
-import { TramOneElement } from './types';
+import { CleanupEffect, TramOneElement } from './types';
 import { getObservableStore } from './observable-store';
 import { TRAM_OBSERVABLE_STORE, TRAM_KEY_STORE } from './engine-names';
 import { decrementKeyStoreValue, getKeyStore, incrementKeyStoreValue } from './key-store';
@@ -54,7 +54,7 @@ const processTramTags = (node: Node | TramOneElement) => {
 			// this is called when an effect is re-triggered
 			const effectReaction = observe(() => {
 				// verify that cleanup is a function before calling it (in case it was a promise)
-				if (typeof cleanup === 'function') cleanup(node);
+				if (typeof cleanup === 'function') cleanup();
 				cleanup = effect(node);
 			});
 
@@ -76,9 +76,8 @@ const processTramTags = (node: Node | TramOneElement) => {
 /**
  * call all cleanup effects on the node
  */
-const cleanupEffects = (node: TramOneElement) => {
-	const cleanupEffects = node[TRAM_TAG_CLEANUP_EFFECTS];
-	cleanupEffects.forEach((cleanup) => cleanup(node));
+const cleanupEffects = (cleanupEffects: CleanupEffect[]) => {
+	cleanupEffects.forEach((cleanup) => cleanup());
 };
 
 /**
@@ -115,7 +114,7 @@ const clearNode = (node: Node | TramOneElement) => {
 	}
 
 	unobserve(node[TRAM_TAG_REACTION]);
-	cleanupEffects(node);
+	cleanupEffects(node[TRAM_TAG_CLEANUP_EFFECTS]);
 	removeStoreKeyAssociation(node[TRAM_TAG_STORE_KEYS]);
 };
 

--- a/src/process-hooks.ts
+++ b/src/process-hooks.ts
@@ -28,15 +28,25 @@ export default (tagFunction: () => TramOneElement) => {
 	const existingEffects = getEffectStore(TRAM_EFFECT_STORE);
 	const queuedEffects = getEffectStore(TRAM_EFFECT_QUEUE);
 
+	// pull new effects that have yet to be processed from the tag
+	// these can appear when a component re-exposes another component at its root
+	const existingNewEffects = tagResult[TRAM_TAG_NEW_EFFECTS] || [];
+
+	// store new effects (and the existing new effects) in the node we just built
+	const newEffects = Object.keys(queuedEffects).filter((effect) => !(effect in existingEffects));
+	const newEffectFunctions = newEffects.map((newEffectKey) => queuedEffects[newEffectKey]);
+	const existingNewAndBrandNewEffects = existingNewEffects.concat(newEffectFunctions);
+	tagResult[TRAM_TAG_NEW_EFFECTS] = existingNewAndBrandNewEffects;
+
+	// same as the existingNewEffects, but for state values
+	const existingNewKeys = tagResult[TRAM_TAG_STORE_KEYS] || [];
+
 	// get all new keys
 	const newKeys = getKeyQueue(TRAM_KEY_QUEUE);
 
-	// store new effects in the node we just built
-	const newEffects = Object.keys(queuedEffects).filter((effect) => !(effect in existingEffects));
-	tagResult[TRAM_TAG_NEW_EFFECTS] = newEffects.map((newEffectKey) => queuedEffects[newEffectKey]);
-
 	// store keys in the node we just built
-	tagResult[TRAM_TAG_STORE_KEYS] = newKeys;
+	const existingNewAndBrandNewKeys = existingNewKeys.concat(newKeys);
+	tagResult[TRAM_TAG_STORE_KEYS] = existingNewAndBrandNewKeys;
 
 	// restore the effect and key queues to what they were before we started
 	restoreEffectStore(TRAM_EFFECT_QUEUE, existingQueuedEffects);

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,13 +48,13 @@ export type StoreObject = [{ [key: string]: any } | any[]][0];
  * Really this is just an annotation to make TramOneElement easier to understand.
  * In reality, this can be a function (to run on removal), or could be nothing.
  */
-export type CleanupEffect = [() => unknown][0];
+export type CleanupEffect = [(ref: TramOneElement) => unknown][0];
 
 /**
  * Type for the effect function.
  * This is passed into the useEffect hook
  */
-export type Effect = [() => unknown][0];
+export type Effect = [(ref: TramOneElement) => unknown][0];
 
 /**
  * The Props interface for custom Tram One Components.

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,7 +48,7 @@ export type StoreObject = [{ [key: string]: any } | any[]][0];
  * Really this is just an annotation to make TramOneElement easier to understand.
  * In reality, this can be a function (to run on removal), or could be nothing.
  */
-export type CleanupEffect = [(ref: TramOneElement) => unknown][0];
+export type CleanupEffect = [() => unknown][0];
 
 /**
  * Type for the effect function.

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,10 +21,10 @@ export type ElementOrSelector = [string | HTMLElement][0];
  * Type for our template renderers (either html or svg).
  * This is not wrapped in an indexed alias, because everything should be provided automatically.
  */
-export type DOMTaggedTemplateFunction = (
+export type DOMTaggedTemplateFunction<TramOneElementType extends TramOneElement> = (
 	strings: TemplateStringsArray,
 	...elementsAndAttributes: any[]
-) => TramOneElement;
+) => TramOneElementType;
 
 /**
  * Type for custom Tram One Components.
@@ -54,7 +54,7 @@ export type CleanupEffect = [() => unknown][0];
  * Type for the effect function.
  * This is passed into the useEffect hook
  */
-export type Effect = [(ref: TramOneElement) => unknown][0];
+export type Effect = [(ref: TramOneHTMLElement | TramOneSVGElement) => unknown][0];
 
 /**
  * The Props interface for custom Tram One Components.
@@ -107,6 +107,9 @@ export interface TramOneElement extends Element {
 	[TRAM_TAG_CLEANUP_EFFECTS]: CleanupEffect[];
 	[TRAM_TAG_STORE_KEYS]: string[];
 }
+
+export type TramOneHTMLElement = TramOneElement & HTMLElement;
+export type TramOneSVGElement = TramOneElement & SVGElement;
 
 /**
  * Type for the Root TramOneComponent,

--- a/src/use-url-params.ts
+++ b/src/use-url-params.ts
@@ -17,7 +17,7 @@ import { UrlMatchResults } from './types';
  *
  * @returns object with a `matches` key, and (if it matched) path and query parameters
  */
-export default (pattern: string): UrlMatchResults => {
+export default (pattern?: string): UrlMatchResults => {
 	// save and update results in an observable, so that we can update
 	// components and effects in a reactive way
 	const initialParams = useUrlParams(pattern) as UrlMatchResults;


### PR DESCRIPTION
## Summary
This PR makes updates to how `useEffect` works, mostly in prep for #173 

Fixes #130 
Fixes #166
Fixes #112 

### Changes
* process existing effects 
  * these were prepared a while ago (in #142), but we finally found a way to test them in #166
* add `ref` parameter to `useEffect`.
  * this has been discussed for a while in #130, this solution feels the most directly applicable, in the example applications built so far.  

### Additional Changes
* changed top level element to be `<tram-one>` rather than `<div>`, this is more clear and obvious, and won't cause formatting issues (since `<tram-one>` should be undecorated). 
  * #112
* make the pattern parameter for `useUrlParams` optional (the underlying library has a default value here, so no parameter should be required).
* Some underlying types were more explicitly defined
  * This was required to make dealing with the `ref` parameter in `useEffect` much easier (and not require wrapping in a cast to `as unknown`).

## Version Bump: Minor
This PR adds new functionality, that should not be breaking in any previously declared way. It's not required by any means for existing projects, so minor feels like the most appropriate here.

## Checklist
- [x] PR Summary
- [x] PR Annotations
- [x] Tests
- [x] Version Bump
